### PR TITLE
add a one-liner to set the binary flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ The package has been grouped into 3 categories:
 
 For more information please view the package documentation: https://bedapub.github.io/besca/
 
-
-
 ## Installation
 
 If you are familiar with python packages simply install it using pip:  
@@ -21,12 +19,23 @@ pip install git+https://github.com/bedapub/besca.git
 ```
 
 Besca comes with a binary called reformat written in C and was compiled in linux-64. Therefore, besca runs exclusively on linux-64.
-In some cases the binary needs to be made executeable. To do so show the location of the path and navigate to the besca package.  
+
+### Set the executable flag to the binary file `reformat` <a name="binary"></a>
+
+In some cases the binary file needs to be made executeable. To do so, run the following one-liner.
+
+```bash
+pip show besca | grep Location | cut -f 2 -d ":" | awk -v OFS="" '{print "chmod u+x" $0 "/besca/export/reformat"}' | bash
+```
+
+If you want to avoid piping to bash, or want to it step by step, here is how to. Show the location of the path and navigate to the besca package.  
+
 ```
 pip show besca
 cd Location/besca
 ```
 Navigate in the directory containing the binary and make it executeable.  
+
 ```
 cd export
 chmod u+x reformat
@@ -39,29 +48,29 @@ If you are not very familiar with python packages here is a detailled descriptio
 If you don't have a conda python installation download and install [miniconda](https://docs.conda.io/en/latest/miniconda.html). While installing I recommend to accept everything asked by the miniconda installation.  
 
 As a next step we create a separate environment for besca which is also called besca.  
+
 ```
 conda create --name besca python=3.7.1
 ```  
+
 We can activate this environment.  
+
 ```
 conda activate besca
 ```
-Within this enviroment we are gonna install besca using pip.  
+
+Within this enviroment we can install besca using pip.  
+
 ```
 pip install git+https://github.com/bedapub/besca.git
-```
-We need to make a binary which comes with besca executeable. To do so show the location of the path and navigate to the besca package.  
-```
-pip show besca
-cd Location/besca
-```
-Navigate in the directory with the binary and make it executeable.  
-```
-cd export
-chmod u+x reformat
+
 ```
 
+Now following the [instrution above](#binary) to set the executable flag to the binary file shipped with besca.
+
 You should now have successfully installed besca.
+
+In case you met any problems, please report an issue.
 
 ## Running besca on a HPC with a SLURM worklod manager  
 


### PR DESCRIPTION
I added a one-liner that sets the executable flag to the reformat binary, and replaced the duplicated paragraphs with an anchor and a link.