### PR TITLE
Qc plot umap add option for leiden/louvain

### DIFF
--- a/besca/st/_qc_report.py
+++ b/besca/st/_qc_report.py
@@ -236,8 +236,8 @@ def write_qc(adata_unfiltered,
             colnames  = list(adata.obs.columns)
 
             # get clustering algotithm to plot, if both computed, choose leiden
-            clust_alg = sort([item for item in colnames if item in ['leiden', 'louvain']])
-            img(src = './figures/umap.' + clust_alg + '.png', width='300px')
+            clust_alg = sorted([item for item in colnames if item in ['leiden', 'louvain']])[0]
+            img(src = './figures/umap.' + str(clust_alg) + '.png', width='300px')
 
 
     with open(join(results_folder, 'qc_report.html'), 'w') as f:

--- a/besca/st/_qc_report.py
+++ b/besca/st/_qc_report.py
@@ -233,7 +233,12 @@ def write_qc(adata_unfiltered,
             br()
 
             h2('Clustering')
-            img(src = './figures/umap.louvain.png', width='300px')
+            colnames  = list(adata.obs.columns)
+
+            # get clustering algotithm to plot, if both computed, choose leiden
+            clust_alg = sort([item for item in colnames if item in ['leiden', 'louvain']])
+            img(src = './figures/umap.' + clust_alg + '.png', width='300px')
+
 
     with open(join(results_folder, 'qc_report.html'), 'w') as f:
             f.write(doc.render())


### PR DESCRIPTION
Last plot (UMAP) in 'qc_report.html' now can be plotted for leiden clustering output 
(before in was for louvain only, and if louvain clustering not computed, 'qc_report.html' did not have the UMAP plot)
https://github.com/bedapub/besca/issues/146#issue-824697811 