### PR TITLE
Add scvi-tools too requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,4 @@ scvelo
 umap-learn
 sinfo
 pydot
-scipy
+scvi-tools


### PR DESCRIPTION
scvi-tools, which we use in the auto-annot module, was missing. scipy turned up twice instead.