### PR TITLE
Updating metadata of notebook: toc creates issues with jupyterlab

### DIFF
--- a/workbooks/celltype_annotation_besca.ipynb
+++ b/workbooks/celltype_annotation_besca.ipynb
@@ -347,10 +347,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "toc-hr-collapsed": true,
-    "toc-nb-collapsed": true
-   },
+   "metadata": { },
    "source": [
     "# Automated annotation\n",
     "\n",


### PR DESCRIPTION
Jupyterlab (HPC  + sHPC) does not handle toc. 
(SEE: https://github.com/jupyterlab/jupyterlab-toc/issues/123).
This creates cells to be hidden and signature notebook is not complete for user when using jupyterlab.

This fixes this issue for now;