### PR TITLE
Simplify standard workflow, and update dependency about scikit-learn

### DIFF
--- a/besca/__init__.py
+++ b/besca/__init__.py
@@ -16,6 +16,7 @@ from ._helper import (
     get_means,
     concate_adata,
     get_singlegenedf,
+    print_software_versions
 )
 
 __all__ = [

--- a/besca/_helper.py
+++ b/besca/_helper.py
@@ -5,6 +5,11 @@ from pandas import DataFrame, concat
 from scipy import sparse
 from math import expm1
 from numpy import sort
+from distutils.version import StrictVersion
+import scanpy as sc
+from collections import namedtuple
+import re
+from ._version import get_versions
 
 
 def subset_adata(adata, filter_criteria, raw=True, axis=0):
@@ -481,3 +486,30 @@ def concate_adata(adata1, adata2):
         adata_combined.raw = adata_combined_raw
 
     return adata_combined
+
+
+def print_software_versions():
+    """Print scanpy and besca software versions
+
+    The function prints scanpy and besca software versions and return them
+    as a named tuple.
+
+    returns
+    -------
+    namedtuple
+        A named tuple containing the versions of scanpy and besca. While
+        only the strict versions are printed, the full version strings are
+        returned.
+    """
+
+    scv = sc.__version__
+    if(StrictVersion(scv) >= "1.6"):
+        sc.logging.print_header()
+    else:
+        sc.logging.print_versions()
+    bcver = get_versions()["version"]
+    bcstr = StrictVersion(re.sub("\\+.*$", "", bcver))
+    print("besca=={}".format(bcstr))
+    Versions = namedtuple('Versions', ['scanpy', 'besca'])
+    res = Versions(scanpy=scv, besca=bcver)
+    return res

--- a/besca/tl/_annot_compare.py
+++ b/besca/tl/_annot_compare.py
@@ -16,9 +16,10 @@ from sklearn.metrics import (
     make_scorer,
     adjusted_mutual_info_score,
     adjusted_rand_score,
-    silhouette_score,
-    pair_confusion_matrix,
+    silhouette_score
 )
+
+from sklearn.metrics.cluster import pair_confusion_matrix
 
 from ..pl._riverplot import riverplot_2categories
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ matplotlib
 bbknn
 ipython
 nbclean
-scikit_learn
+scikit_learn>=1.0.2
 python-igraph
 leidenalg
 scanorama

--- a/workbooks/standard_workflow_besca2.ipynb
+++ b/workbooks/standard_workflow_besca2.ipynb
@@ -29,24 +29,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Global seed set to 0\n",
+      "/mnt/projects/miniconda3/envs/besca/lib/python3.7/site-packages/numba/np/ufunc/parallel.py:363: NumbaWarning: \u001b[1mThe TBB threading layer requires TBB version 2019.5 or later i.e., TBB_INTERFACE_VERSION >= 11005. Found TBB_INTERFACE_VERSION = 9107. The TBB threading layer is disabled.\u001b[0m\n",
+      "  warnings.warn(problem)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "scanpy==1.6.0 anndata==0.7.5 umap==0.4.6 numpy==1.20.2 scipy==1.5.4 pandas==1.2.3 scikit-learn==1.0.2 statsmodels==0.12.1 python-igraph==0.8.3 leidenalg==0.8.3\n",
+      "besca==2.2.4\n"
+     ]
+    }
+   ],
    "source": [
-    "from  distutils.version import StrictVersion\n",
     "import scanpy as sc\n",
     "import besca as bc \n",
-    "import re\n",
     "\n",
-    "def print_software_versions():\n",
-    "    scv = sc.__version__\n",
-    "    if(StrictVersion(scv) >= \"1.6\"):\n",
-    "        sc.logging.print_header()\n",
-    "    else:\n",
-    "        sc.logging.print_versions()\n",
-    "    bcstr = StrictVersion(re.sub(\"\\+.*$\", \"\", bc.__version__))\n",
-    "    print(\"besca=={}\".format(bcstr))\n",
-    "    return None"
+    "vers = bc.print_software_versions()"
    ]
   },
   {
@@ -1194,7 +1202,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python3.7 (besca_dev)",
+   "display_name": "besca_dev",
    "language": "python",
    "name": "besca_dev"
   },

--- a/workbooks/standard_workflow_besca2.ipynb
+++ b/workbooks/standard_workflow_besca2.ipynb
@@ -29,27 +29,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Global seed set to 0\n",
-      "/mnt/projects/miniconda3/envs/besca/lib/python3.7/site-packages/numba/np/ufunc/parallel.py:363: NumbaWarning: \u001b[1mThe TBB threading layer requires TBB version 2019.5 or later i.e., TBB_INTERFACE_VERSION >= 11005. Found TBB_INTERFACE_VERSION = 9107. The TBB threading layer is disabled.\u001b[0m\n",
-      "  warnings.warn(problem)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "scanpy==1.6.0 anndata==0.7.5 umap==0.4.6 numpy==1.20.2 scipy==1.5.4 pandas==1.2.3 scikit-learn==1.0.2 statsmodels==0.12.1 python-igraph==0.8.3 leidenalg==0.8.3\n",
-      "besca==2.2.4\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import scanpy as sc\n",
     "import besca as bc \n",


### PR DESCRIPTION
I made two changes:
1. I put the function print_software_versions() in `_helper.py`, which makes the standard workflow easier to read
2. I updated the dependency on scikit-learn due to the API change of that library.