### PR TITLE
GitHub action to deploy besca to PyPI on new release

### DIFF
--- a/.github/workflows/pypi-auto-deploy.yml
+++ b/.github/workflows/pypi-auto-deploy.yml
@@ -1,0 +1,32 @@
+name: Publish Besca to PyPI # and Test PyPI
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build-n-publish:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel
+    - name: Build a binary wheel and a source tarball
+      run: |
+        python setup.py sdist bdist_wheel
+    - name: Publish distribution package to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}
+    # - name: Publish distribution package to Test PyPI
+    #   uses: pypa/gh-action-pypi-publish@master
+    #   with:
+    #     password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+    #     repository_url: https://test.pypi.org/legacy/ 


### PR DESCRIPTION
Implemented a GitHub Action that automatically deploys besca to PyPI when a new release is created.