### PR TITLE
Bug Fix: in commit f6c914a, regress_out was removed and only scaling …

### DIFF
--- a/workbooks/standard_workflow_besca2.ipynb
+++ b/workbooks/standard_workflow_besca2.ipynb
@@ -675,10 +675,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# RMK : AS OF FEB 2020 there is a bug in scanpy regress out if scanpy installed with PIP (see https://github.com/theislab/scanpy/issues/707)\n",
-    "# Before the fix is available, one should coopy the data to prevent it. hence the adata = adata.copy()\n",
-    "adata = adata.copy()\n",
-    "adata = sc.pp.scale(adata, max_value=10)"
+    "sc.pp.scale(adata, max_value=10, copy=False)"
    ]
   },
   {


### PR DESCRIPTION
Bug Fix: in commit f6c914a, regress_out was removed and only scaling is done, which is expected; however, the current version is buggy because by default the function sc.pp.scale updates adata, not return a copy of it. Now I make copy explicitly False, fix the bug, and remove the outdated comment.

After merging, feel free to delete the 20220821-Accio-swscale branch.