### PR TITLE
Critical Bug fix: in highly_variable_genes

### DIFF
--- a/besca/st/_wrapper_funcs.py
+++ b/besca/st/_wrapper_funcs.py
@@ -350,7 +350,7 @@ def highly_variable_genes(adata, batch_key=None, n_shared=2):
 
     pl_highly_variable_genes(adata, save=".hvg.png", show=True)
 
-    adata = adata[:, adata.var.highly_variable is True]
+    adata = adata[:, adata.var.highly_variable == True]
 
     # logging
     logging.info(

--- a/tests/test_wrapper_funcs.py
+++ b/tests/test_wrapper_funcs.py
@@ -3,16 +3,35 @@ import pytest
 from typing import List
 from os.path import join
 import filecmp
+from random import sample
 
 from scvelo import AnnData
 
 import besca as bc
-from besca.st._wrapper_funcs import additional_labeling
+import scanpy as sc
+from besca.st._wrapper_funcs import additional_labeling, highly_variable_genes
+
+
+pytest.raw_data_subset_size = 1000
 
 
 @pytest.fixture(scope="session")
 def load_kotliarov2020_processed_data() -> AnnData:
     return bc.datasets.Kotliarov2020_processed()
+
+
+@pytest.fixture(scope="session")
+def load_kotliarov2020_raw_data() -> AnnData:
+    return bc.datasets.Kotliarov2020_raw()
+
+
+@pytest.fixture(scope="session")
+def subset_kotliarov2020_raw_data(load_kotliarov2020_raw_data: AnnData) -> AnnData:
+    subset = sample(
+        [i for i in range(load_kotliarov2020_raw_data.shape[0])],
+        pytest.raw_data_subset_size,
+    )
+    return load_kotliarov2020_raw_data[subset, :]
 
 
 @pytest.fixture
@@ -81,3 +100,13 @@ def test_additional_labeling(
         identical: bool = filecmp.cmp(reference_file, output_file, shallow=False)
 
         assert identical is True, f"File {file} is not as expected!"
+
+
+def test_highly_variable_genes(subset_kotliarov2020_raw_data: AnnData):
+
+    adata = highly_variable_genes(
+        adata=subset_kotliarov2020_raw_data, batch_key=None, n_shared=2
+    )
+    # ensure that we get all hvgs and not just one
+    assert adata.shape[0] == pytest.raw_data_subset_size
+    assert adata.shape[1] == 1478


### PR DESCRIPTION
The last commit (0f91a04) introduced `is True` instead of `== True`, which unfortunately will keep only ONE gene left. This is now reverted. @kohleman for your information.