### PR TITLE
Fixed split_gene_expression bug related to figsize

### DIFF
--- a/besca/pl/_general.py
+++ b/besca/pl/_general.py
@@ -70,7 +70,7 @@ def split_violin(
     ax.tick_params(labelrotation=90, length=6, width=2)
     
     if figsize is not None:
-        plt.figure(figsize=figsize)
+        figure(figsize=figsize)
 
     return None
 
@@ -421,7 +421,7 @@ def flex_dotplot(df,X,Y,HUE,SIZE,title, mycolors='Reds', myfontsize=15,  xfactor
     setp(ax.get_legend().get_title(), fontsize=myfontsize)  # for legend title
     setp(ax.get_legend().get_texts(), fontsize=myfontsize - 2)  # for legend text
     if figsize is not None:
-        plt.figure(figsize=figsize)
+        figure(figsize=figsize)
     ax.legend(framealpha=0.4, bbox_to_anchor=(1.01, 1), borderaxespad=0.5)
     mm = my = 0.2
     if df[X].nunique() >= 10:

--- a/besca/pl/_split_gene_expression.py
+++ b/besca/pl/_split_gene_expression.py
@@ -213,13 +213,14 @@ def gene_expr_split(
         x_axis="gene",
         y_axis="expression",
         split_variable=label_split_variable,
+        figsize=figsize,
         order=None,
         ax=ax,
     )
     
-    if figsize is not None:
-        fig.set_figheight(height[1])
-        fig.set_figwidth(width[0])
+    #if figsize is not None:
+    #    fig.set_figheight(figsize[1])
+    #    fig.set_figwidth(figsize[0])
     return None
 
 
@@ -231,11 +232,10 @@ def gene_expr_split_stacked(
     subset_variable="celltype",
     label_subset_variable=None,
     use_raw=True,
-    fig_width=None,
-    fig_height=None,
+     figsize=(15,8),
     order=None,
     inner="stick",
-    figsize=(15,8)
+
 ):
 
     """
@@ -314,12 +314,11 @@ def gene_expr_split_stacked(
         split_variable=label_split_variable,
         subset_variable_label="gene",
         subset_variables=genes,
-        fig_width=fig_width,
-        fig_height=fig_height,
+        figsize=figsize,
         order=order,
         inner=inner,
     )
-    if figsize is not None:
-        fig.set_figheight(height[1])
-        fig.set_figwidth(width[0])
+    #if figsize is not None:
+    #    fig.set_figheight(height[1])
+    #    fig.set_figwidth(width[0])
     return fig

--- a/workbooks/Signature_exports.ipynb
+++ b/workbooks/Signature_exports.ipynb
@@ -623,9 +623,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "besca_dev",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "besca_dev"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -637,7 +637,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/workbooks/minimal_notebook.ipynb
+++ b/workbooks/minimal_notebook.ipynb
@@ -37,9 +37,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "besca_dev",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "besca_dev"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -51,7 +51,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Had some errors when running bc.pl.gene_expr_split() - first "plt" was not found and then several issues with  fig.set_figwidth and the height, width parameters. Runs now for me with the modifs I made would be great if you could also check that all is fine. Thnx!