### PR TITLE
20230417 david stdwf format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,4 @@ coverage.xml
 # Sphinx documentation
 docs/_build/
 
-.vscode
+.vscode*.lock

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ coverage.xml
 docs/_build/
 
 .vscode*.lock
+*.lock

--- a/workbooks/celltype_annotation_besca.ipynb
+++ b/workbooks/celltype_annotation_besca.ipynb
@@ -494,7 +494,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Automated annotation\n",
+    "## Automated annotation\n",
     "\n",
     "A decision-tree-based annotation that reads signatures from a provided .gmt file and hierarchy as well as cutoffs and signature ordering from a configuration file and attributes each cell to a specific type according to signature enrichment. \n",
     "\n",
@@ -505,7 +505,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Loading markers and signature"
+    "### Loading markers and signature"
    ]
   },
   {
@@ -598,7 +598,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Configuration of the annotation\n",
+    "### Configuration of the annotation\n",
     "\n",
     "We read the configuration file, containing hierarchy, cutoff and signature priority information. \n",
     "A new version of this file should be created and maintained with each annotation. \n",
@@ -1576,7 +1576,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.9.10"
   },
   "toc-autonumbering": false,
   "toc-showcode": false,

--- a/workbooks/standard_workflow_besca2.ipynb
+++ b/workbooks/standard_workflow_besca2.ipynb
@@ -367,8 +367,8 @@
    "outputs": [],
    "source": [
     "fig, ((ax1, ax2, ax3), (ax4, ax5, ax6)) = plt.subplots(ncols=3, nrows=2)\n",
-    "fig.set_figwidth(17)\n",
-    "fig.set_figheight(9)\n",
+    "fig.set_figwidth(12)\n",
+    "fig.set_figheight(7)\n",
     "fig.tight_layout(pad=4.5)\n",
     "\n",
     "bc.pl.kp_genes(adata, min_genes=standard_min_genes, ax = ax1)\n",
@@ -409,7 +409,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc.pl.violin(adata, ['percent_mito','n_genes', 'n_counts'], groupby=split_condition,jitter=0.1,rotation=90, save = '.before_filtering.split.png')"
+    "sc.pl.violin(adata, ['n_genes', 'n_counts', 'percent_mito'], groupby=split_condition,jitter=0.1,rotation=90, save = '.before_filtering.split.png')"
    ]
   },
   {

--- a/workbooks/standard_workflow_besca2.ipynb
+++ b/workbooks/standard_workflow_besca2.ipynb
@@ -371,12 +371,12 @@
     "fig.set_figheight(7)\n",
     "fig.tight_layout(pad=4.5)\n",
     "\n",
-    "bc.pl.kp_genes(adata, min_genes=standard_min_genes, ax = ax1)\n",
-    "bc.pl.kp_counts(adata, min_counts=standard_min_counts, ax = ax2)\n",
-    "bc.pl.kp_cells(adata, min_cells=standard_min_cells, ax = ax3)\n",
-    "bc.pl.max_genes(adata, max_genes=standard_n_genes, ax = ax4)\n",
-    "bc.pl.max_mito(adata, max_mito=standard_percent_mito, annotation_type='SYMBOL', species=species, ax = ax5)\n",
-    "bc.pl.max_counts(adata, max_counts=standard_max_counts, ax=ax6)\n",
+    "bc.pl.kp_genes(adata_unfiltered, min_genes=standard_min_genes, ax = ax1)\n",
+    "bc.pl.kp_counts(adata_unfiltered, min_counts=standard_min_counts, ax = ax2)\n",
+    "bc.pl.kp_cells(adata_unfiltered, min_cells=standard_min_cells, ax = ax3)\n",
+    "bc.pl.max_genes(adata_unfiltered, max_genes=standard_n_genes, ax = ax4)\n",
+    "bc.pl.max_mito(adata_unfiltered, max_mito=standard_percent_mito, annotation_type='SYMBOL', species=species, ax = ax5)\n",
+    "bc.pl.max_counts(adata_unfiltered, max_counts=standard_max_counts, ax=ax6)\n",
     "fig.savefig(os.path.join(results_folder, 'figures/filtering_thresholds.png'), format='png', bbox_inches = 'tight') #save figure for QC report"
    ]
   },
@@ -1052,9 +1052,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "besca_dev",
    "language": "python",
-   "name": "python3"
+   "name": "besca_dev"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1066,7 +1066,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.14"
+   "version": "3.9.10"
   },
   "toc": {
    "base_numbering": 1,

--- a/workbooks/standard_workflow_besca2.ipynb
+++ b/workbooks/standard_workflow_besca2.ipynb
@@ -367,9 +367,9 @@
    "outputs": [],
    "source": [
     "fig, ((ax1, ax2, ax3), (ax4, ax5, ax6)) = plt.subplots(ncols=3, nrows=2)\n",
-    "fig.set_figwidth(12)\n",
-    "fig.set_figheight(7)\n",
-    "fig.tight_layout(pad=4.5)\n",
+    "fig.set_figwidth(10)\n",
+    "fig.set_figheight(6)\n",
+    "fig.tight_layout(pad=4)\n",
     "\n",
     "bc.pl.kp_genes(adata_unfiltered, min_genes=standard_min_genes, ax = ax1)\n",
     "bc.pl.kp_counts(adata_unfiltered, min_counts=standard_min_counts, ax = ax2)\n",
@@ -393,7 +393,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc.pl.violin(adata, ['n_genes', 'n_counts', 'percent_mito'], jitter=0.2, multi_panel=True, save = '.before_filtering.png')"
+    "sc.pl.violin(adata_unfiltered, ['n_genes', 'n_counts', 'percent_mito'], jitter=0.2, multi_panel=True, save = '.before_filtering.png')"
    ]
   },
   {
@@ -409,7 +409,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc.pl.violin(adata, ['n_genes', 'n_counts', 'percent_mito'], groupby=split_condition,jitter=0.1,rotation=90, save = '.before_filtering.split.png')"
+    "sc.pl.violin(adata_unfiltered, ['n_genes', 'n_counts', 'percent_mito'], groupby=split_condition,jitter=0.1,rotation=90, save = '.before_filtering.split.png')"
    ]
   },
   {
@@ -467,6 +467,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "adata_raw = adata.copy()"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -479,7 +488,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sc.pl.violin(adata, ['n_genes', 'n_counts', 'percent_mito'], jitter=0.2, multi_panel=True, save = '.after_filtering.png')"
+    "sc.pl.violin(adata_raw, ['n_genes', 'n_counts', 'percent_mito'], jitter=0.2, multi_panel=True, save = '.after_filtering.png')"
    ]
   },
   {
@@ -498,7 +507,7 @@
    "outputs": [],
    "source": [
     "# check mitochondrial reads per sample \n",
-    "sc.pl.violin(adata, ['percent_mito','n_genes', 'n_counts'], groupby=split_condition,jitter=0.1,rotation=90, save = '.after_filtering.split.png')"
+    "sc.pl.violin(adata_raw, ['n_genes', 'n_counts', 'percent_mito'], groupby=split_condition,jitter=0.1,rotation=90, save = '.after_filtering.split.png')"
    ]
   },
   {
@@ -508,7 +517,7 @@
    "outputs": [],
    "source": [
     "# cell counts per sample\n",
-    "temp=bc.tl.count_occurrence(adata,split_condition)\n",
+    "temp=bc.tl.count_occurrence(adata_raw, split_condition)\n",
     "sns.barplot(y=temp.index,x=temp.Counts,color='gray',orient='h')"
    ]
   },
@@ -520,7 +529,7 @@
    "source": [
     "#display the top 25 genes in the dataset\n",
     "fig, ax = plt.subplots(ncols=1, nrows=1, figsize = (8, 6))\n",
-    "bc.pl.top_genes_counts(adata=adata, top_n=25, ax = ax )\n",
+    "bc.pl.top_genes_counts(adata=adata_raw, top_n=25, ax = ax )\n",
     "fig.savefig(os.path.join(results_folder, 'figures/top_genes.png'), format='png', bbox_inches = 'tight') #save figure for QC report"
    ]
   },
@@ -530,7 +539,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "adata.var"
+    "adata_raw.var"
    ]
   },
   {
@@ -540,7 +549,7 @@
    "outputs": [],
    "source": [
     "# Export adata object with raw counts and filtered cells/genes (might be needed by other analyses)\n",
-    "adata.write(results_file_raw)"
+    "adata_raw.write(results_file_raw)"
    ]
   },
   {
@@ -556,7 +565,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "adata = bc.st.per_cell_normalize(adata, results_folder)"
+    "adata = bc.st.per_cell_normalize(adata_raw, results_folder)"
    ]
   },
   {


### PR DESCRIPTION
Minor changes to standard workflow:
1. the 3x2 QC plot is made compact
2. adata is replaced by adata_unfiltered, adata_raw, and adata, to allow the ealier codes executable even after later codes are executed
3. the ordering of n_genes, n_counts, and n_mito is fixed