### PR TITLE
Added keratinocyte and melanocyte sig and fixed neutrophil #289

### DIFF
--- a/besca/datasets/genesets/CellNames_scseqCMs6_config.mouse.tsv
+++ b/besca/datasets/genesets/CellNames_scseqCMs6_config.mouse.tsv
@@ -123,3 +123,5 @@ Eosinophil	Granulocyte	1	82.5
 ResourceCD8Tcell	CD8Tcell	4	120
 Microglia	Macrophage	1	121
 MAIT	Tcell	1	122
+Keratinocyte	Epithelial	2	11
+Melanocyte	None	2	71

--- a/besca/datasets/genesets/CellNames_scseqCMs6_config.tsv
+++ b/besca/datasets/genesets/CellNames_scseqCMs6_config.tsv
@@ -122,3 +122,5 @@ Eosinophil	Granulocyte	1	82.5
 Microglia	Macrophage	1	121
 ResourceCD8Tcell	CD8Tcell	4	120
 MAIT	Tcell	2	13.5
+Keratinocyte	Epithelial	2	11
+Melanocyte	None	2	71

--- a/besca/datasets/genesets/CellNames_scseqCMs6_sigs.gmt
+++ b/besca/datasets/genesets/CellNames_scseqCMs6_sigs.gmt
@@ -1,14 +1,14 @@
 Bcell	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (v9 Sep21) derived by LAS and PCS	CD19	MS4A1	TNFRSF13C	VPREB3	PAX5	CR2												
 Fibroblast	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (v9 Sep21) derived by LAS and PCS	PDGFRB	DCN	PCOLCE	EMILIN1	CYGB	MFAP4	TCF21	BGN	ACTA2									
 Endothelial	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (v9 Sep21) derived by LAS and PCS	CDH5	ECSCR	CCL14	KDR	TIE1	PCAT19	MYCT1	FLT4										
-Epithelial	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (v9 Sep21) derived by LAS and PCS	EPCAM	KLK1	SMIM22	LGALS4	CLDN7	CDH1	HMGCS2											
+Epithelial	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (v9 Sep21) derived by LAS and PCS	EPCAM	KLK1	SMIM22	LGALS4	CLDN7	CDH1	HMGCS2	SERPINB5										
 Granulocyte	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (v9 Sep21) derived by LAS and PCS	MPO	CTSG	FCGR3B	CLC	HDC													
 MelMelanoma	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (v8 May20) derived by Schwalie P.	MIA	TYR	SLC45A2	CDH19	PMEL	SLC24A5	MAGEA6	GJB1	PLP1	PRAME	CAPN3	ERBB3	GPM6B	S100B	PAX3	S100A1	MLANA	
 MemBcell	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (v8 May20) derived by Schwalie P.	TNFRSF13B	AIM2	IGHG1	IGHG2	CLECL1	IGHA1												
 Myeloid	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (v9 Sep21) derived by LAS and PCS	CSF3R	MS4A6A	MS4A7	MNDA	C5AR1	FCGR2A	C3AR1	FPR1	LILRB2	HDC	FCGR3B	CCL22						
 NKcell	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (v9 Sep21) derived by LAS and PCS	NCR1	LIM2	KIR2DL4	KLRC1	IL18RAP	KLRF1												
 NaiBcell	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (v8 May20) derived by Schwalie P.	IGHD	IGHM	CD72	TCL1A	FCER2	BTLA	FCRL1											
-Neutrophil	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (v9 Sep21) derived by LAS and PCS	ELANE	MPO	PRTN3	CTSG	AZU1	FCGR3B CXCR2  												
+Neutrophil	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (v9 Sep21) derived by LAS and PCS	ELANE	MPO	PRTN3	CTSG	AZU1	FCGR3B	CXCR2												
 Plasma	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (v9 Sep21) derived by LAS and PCS	JSRP1	DERL3	FCRL2	FCRL5	IGLL5	TNFRSF17												
 CD4Tcell	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (v9 Sep21) derived by LAS and PCS	CD4	TRAT1	CD40LG	LEF1	TNFRSF4													
 CD8Tcell	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (v9 Sep21) derived by LAS and PCS	CD8A	CD8B																
@@ -121,3 +121,5 @@ Eosinophil	"Genes derived from literature and expression checked in tested in se
 Microglia	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (v9 Sep21) derived by LAS and PCS	P2RY12	SIGLEC8	TMEM119															
 ResourceCD8Tcell	"Genes derived from literature and expression checked in tested in a single mouse dataset. To be further tested and validated. Derived by PCS, Sep21"	S1PR5	KLRG1	SLAMF6	CXCR3	S1PR1	ITGB7	CD8A	IL7R	TCF7	PDCD1								
 MAIT	Genes derived from literature and DGE analysis of MAIT cells in WB_Glofit study annotated with reference atlas. Derived by LAS Oct21 	CD8A	KLRB1	CXCR6	CCR6	SLC4A10	LTK												
+Keratinocyte	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (Mar23) derived by PCS 	LGALS7	LGALS7B	DSC3	DSG1	LY6D	FAM83B	SERPINB5								
+Melanocyte	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (Mar23) derived by PCS 	MLANA	DCT	TYRP1	PMEL	TRPM1	GPR143	TYR								

--- a/besca/datasets/genesets/CellNames_scseqCMs6_sigs.mouse.gmt
+++ b/besca/datasets/genesets/CellNames_scseqCMs6_sigs.mouse.gmt
@@ -1,14 +1,14 @@
 Bcell	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (v9 Sep21) derived by LAS and PCS	Cd19	Ms4a1	Tnfrsf13c	Vpreb3	Pax5	Cr2													
 Fibroblast	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (v9 Sep21) derived by LAS and PCS	Mfap4	Col6a1	Col1a1	Cygb	Dcn	Pdgfrb	Col3a1	Bgn	Acta2	Nefl									
 Endothelial	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (v9 Sep21) derived by LAS and PCS	Tie1	Cyrr1	Mmrn2	Sox18	Gpr182	Sox17	Myct1	Cldn5	Gpihbp1	Arhgef15									
-Epithelial	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (v9 Sep21) derived by LAS and PCS	Sftpd	Pigr	Scgb3a1	Hmgcs2	Lgals4	Epcam	Cldn7	Smim22	Mal2										
+Epithelial	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (v9 Sep21) derived by LAS and PCS	Sftpd	Pigr	Scgb3a1	Hmgcs2	Lgals4	Epcam	Cldn7	Smim22	Mal2	Serpinb5									
 Granulocyte	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (v9 Sep21) derived by LAS and PCS	Mpo	Ctsg	Mmp9	Clc	Hdc														
 MelMelanoma	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (v9 Sep21) derived by LAS and PCS	Gm21983	Tyr	Slc45a2	Cdh19	Pmel	Slc24a5	Gjb1	Plp1	Capn3	Erbb3	Gpm6b	S100b	Pax3	S100a1	Mlana				
 MemBcell	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (v9 Sep21) derived by LAS and PCS	Tnfrsf13b	Aim2	Igha	Ighg1	Ighg2a	Ighg2b	Ighg2c												
 Myeloid	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (v9 Sep21) derived by LAS and PCS	Clec4a3	Clec4a1	Fcgr1	Lst1	Fcgr2b	Ms4a6d	Cfp	Clec5a	Mcemp1	Cpa3	Clec4e	C5ar1	Chil3	Flt3	Batf3				
 NKcell	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (v9 Sep21) derived by LAS and PCS	Ncr1	Klri2	Klrb1a	Klra9															
 NaiBcell	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (v9 Sep21) derived by LAS and PCS	Ighm	Cd72	Tcl1	Fcer2a	Btla	Fcrl1													
-Neutrophil	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (v9 Sep21) derived by LAS and PCS	Elane	Mpo	Prtn3	Ctsg	Ly6g	Mmp9  Cxcr2													
+Neutrophil	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (v9 Sep21) derived by LAS and PCS	Elane	Mpo	Prtn3	Ctsg	Ly6g	Mmp9	Cxcr2													
 Plasma	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (v9 Sep21) derived by LAS and PCS	Fcrl5	Iglc1	Iglc3	Iglc4	Iglc2	Cd79a													
 CD4Tcell	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (v9 Sep21) derived by LAS and PCS	Cd4	Trat1	Cd40lg	Tnfrsf4															
 CD8Tcell	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (v9 Sep21) derived by LAS and PCS	Cd8a	Cd8b1																	
@@ -122,3 +122,5 @@ Eosinophil	"Genes derived from human homology and literature. To be further test
 ResourceCD8Tcell	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (v9 Sep21) derived by LAS and PCS	Tcf7	Pdcd1	Cd8b1	S1pr5	S1pr1	Ly6c2	Cxcr3	Slamf6	Ccr2	Itgb7	Il7r								
 Microglia	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (v9 Sep21) derived by LAS and PCS	Gpr84	Mertk	Gpr34	Trem2															
 MAIT	Genes derived from literature and DGE analysis of MAIT cells in WB_Glofit study annotated with reference atlas. Derived by LAS Oct21. Needs more testing in mouse datasets 	Cd8a	Klrb1	Cxcr6	Ccr6	Slc4a10	Ltk													
+Keratinocyte	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (Mar23) derived by PCS in human, needs testing in mouse datasets 	Lgals7	Dsc3	Dsg1a	Ly6d	Fam83b	Serpinb5								
+Melanocyte	Genes used for automatic annotation of scRNA-seq derived clusters of PBMCs/TILs (Mar23) derived by PCS in human, needs testing in mouse datasets 	Mlana	Dct	Tyrp1	Pmel	Cdk2	Gpr143	Trpm1	Tyr								


### PR DESCRIPTION
I put together a signature for keratinocytes and melanocytes and added them to sig-annot. In addition I fixed a small typo regarding the neutrophil sig flagged by @llumdi in issue #289 