### PR TITLE
Fix empty `levsk` while reading annotation config for pandas 2.0

### DIFF
--- a/besca/tl/sig/_annot.py
+++ b/besca/tl/sig/_annot.py
@@ -137,11 +137,10 @@ def read_annotconfig(configfile: str):
         String of distinct levels based on configuration file
     """
     # read the config file
-    sigconfig = pd.read_csv(configfile, sep="\t", index_col=0)
+    sigconfig = pd.read_csv(configfile, sep="\t", index_col=0, na_filter=False)
     # Reorder with the specified order. Place better signatures first, only first match will be kept
     sigconfig = sigconfig.sort_values("Order")
     # Consider up to 7 levels
-    nochild = list(set(sigconfig.index) - set(sigconfig["Parent"]))
     levs = []
     levs.append(
         list(


### PR DESCRIPTION
Since `pandas` release v2.0, `None` was added to the list of default NA values, making the current implementation not able to read cell hierarchy correctly from the configuration file.

This PR closes #299 by adding `na_filter` to `read_csv` in `read_annotconfig` to avoid not being able to identify `"None"` in `sigconfig["Parent"]`.