### PR TITLE
Updated dblabels to correspond to db

### DIFF
--- a/besca/datasets/nomenclature/CellTypes_v1.tsv
+++ b/besca/datasets/nomenclature/CellTypes_v1.tsv
@@ -1,5 +1,5 @@
 dblabel	dblabelEFO	EFO	short_dblabel	is_level	l4	l4EFO	l3	l3EFO	l2	l2EFO	l1	l1EFO	l0	l0EFO
-Use this one for labelling	identical to dblabel if EFO term present	"EFO ID if present, otherwise internal DB ID"	Used only for plotting; should also be unique & consistent	hierarchy level										
+Use this one for labelling	identical to dblabel if EFO term present	EFO ID if present, otherwise internal DB ID	Used only for plotting; should also be unique & consistent	hierarchy level										
 cultured cell	cultured cell	CL:0000010	Cultured	0										
 germ line stem cell	germ line stem cell	CL:0000014	GermLineStem	3					stem cell	CL:0000034	precursor cell	CL:0011115	cell	CL:0000548
 male germ line stem cell	male germ line stem cell	CL:0000016	MaleGerm	4			germ line stem cell	CL:0000014	stem cell	CL:0000034	precursor cell	CL:0011115	cell	CL:0000548
@@ -68,12 +68,12 @@ keratinocyte	keratinocyte	CL:0000312	Keratinocyte	4			epidermal cell	CL:0000362	
 pneumocyte	pneumocyte	CL:0000322	Pneumocyte	3					epithelial cell of lung	CL:0000082	epithelial cell	CL:0000066	cell	CL:0000548
 epidermal cell	epidermal cell	CL:0000362	Epidermal	3					ecto-epithelial cell	CL:0002077	epithelial cell	CL:0000066	cell	CL:0000548
 Langerhans cell	Langerhans cell	CL:0000453	Langerhans	4			myeloid dendritic cell	CL:0000782	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
-CD4-positive helper T cell	CD4-positive helper T cell	CL:0000492	ThCD4Tcell	5	"CD4-positive, alpha-beta T cell"	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+CD4-positive helper T cell	CD4-positive helper T cell	CL:0000492	ThCD4Tcell	5	CD4-positive, alpha-beta T cell	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
 stromal cell	stromal cell	CL:0000499	Stromal	2							connective tissue cell	CL:0002320	cell	CL:0000548
 paneth cell	paneth cell	CL:0000510	Paneth	4			intestinal epithelial cell	CL:0002563	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	cell	CL:0000548
 neuron	neuron	CL:0000540	Neuron	2							neural cell	CL:0002319	cell	CL:0000548
 lymphocyte	lymphocyte	CL:0000542	Lymphocyte	2							hematopoietic cell	CL:0000988	cell	CL:0000548
-T-helper 1 cell	T-helper 1 cell	CL:0000545	Th1CD4Tcell	5	"CD4-positive, alpha-beta T cell"	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+T-helper 1 cell	T-helper 1 cell	CL:0000545	Th1CD4Tcell	5	CD4-positive, alpha-beta T cell	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
 proerythroblast	proerythroblast	CL:0000547	Proerythroblast	3					erythroid lineage cell	CL:0000764	hematopoietic cell	CL:0000988	cell	CL:0000548
 cell	cell	CL:0000548	Cell	0										
 megakaryocyte	megakaryocyte	CL:0000556	Megakaryocyte	2							hematopoietic cell	CL:0000988	cell	CL:0000548
@@ -90,8 +90,8 @@ retinal rod cell	retinal rod cell	CL:0000604	RetinalRod	5	photoreceptor cell	CL:
 GABAergic neuron	GABAergic neuron	CL:0000617	GABAergicN	3					neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
 acinar cell	acinar cell	CL:0000622	Acinar	3					glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	cell	CL:0000548
 natural killer cell	natural killer cell	CL:0000623	NKcell	4			innate lymphoid cell	CL:0001065	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
-"CD4-positive, alpha-beta T cell"	"CD4-positive, alpha-beta T cell"	CL:0000624	CD4Tcell	4			T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
-"CD8-positive, alpha-beta T cell"	"CD8-positive, alpha-beta T cell"	CL:0000625	CD8Tcell	4			T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+CD4-positive, alpha-beta T cell	CD4-positive, alpha-beta T cell	CL:0000624	CD4Tcell	4			T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+CD8-positive, alpha-beta T cell	CD8-positive, alpha-beta T cell	CL:0000625	CD8Tcell	4			T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
 Mueller cell	Mueller cell	CL:0000636	Mueller	5	astrocyte	CL:0000127	macroglial cell	CL:0000126	glial cell	CL:0000125	neural cell	CL:0002319	cell	CL:0000548
 Bergmann glial cell	Bergmann glial cell	CL:0000644	BergmannGlial	5	astrocyte	CL:0000127	macroglial cell	CL:0000126	glial cell	CL:0000125	neural cell	CL:0002319	cell	CL:0000548
 basal cell	basal cell	CL:0000646	Basal	5	epithelial fate stem cell	CL:0000036	somatic stem cell	CL:0000723	stem cell	CL:0000034	precursor cell	CL:0011115	cell	CL:0000548
@@ -129,7 +129,7 @@ plasmacytoid dendritic cell	plasmacytoid dendritic cell	CL:0000784	pDC	3					lym
 plasma cell	plasma cell	CL:0000786	Plasma	3					lymphocyte of B lineage	CL:0000945	hematopoietic cell	CL:0000988	cell	CL:0000548
 memory B cell	memory B cell	CL:0000787	MemBcell	4			B cell	CL:0000236	lymphocyte of B lineage	CL:0000945	hematopoietic cell	CL:0000988	cell	CL:0000548
 naive B cell	naive B cell	CL:0000788	NaiBcell	4			B cell	CL:0000236	lymphocyte of B lineage	CL:0000945	hematopoietic cell	CL:0000988	cell	CL:0000548
-"CD8-positive, alpha-beta cytotoxic T cell"	"CD8-positive, alpha-beta cytotoxic T cell"	CL:0000794	CytotoxCD8Tcell	5	"CD8-positive, alpha-beta T cell"	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+CD8-positive, alpha-beta cytotoxic T cell	CD8-positive, alpha-beta cytotoxic T cell	CL:0000794	CytotoxCD8Tcell	5	CD8-positive, alpha-beta T cell	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
 gamma-delta T cell	gamma-delta T cell	CL:0000798	gdTcell	4			T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
 memory T cell	memory T cell	CL:0000813	MemTcell	4			T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
 mature NK T cell	mature NK T cell	CL:0000814	NKTcell	4			T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
@@ -149,20 +149,20 @@ non-classical monocyte	non-classical monocyte	CL:0000875	NClassMonocyte	4			mono
 central nervous system macrophage	central nervous system macrophage	CL:0000878	CNSMacrophage	4			macrophage	CL:0000235	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
 perivascular macrophage	perivascular macrophage	CL:0000881	PerivascMacrophage	5	central nervous system macrophage	CL:0000878	macrophage	CL:0000235	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
 DN1 thymic pro-T cell	DN1 thymic pro-T cell	CL:0000894	DN1ProTcell	4			pro-T cell	CL:0000827	lymphoid lineage restricted progenitor cell	CL:0000838	hematopoietic cell	CL:0000988	cell	CL:0000548
-"naive thymus-derived CD4-positive, alpha-beta T cell"	"naive thymus-derived CD4-positive, alpha-beta T cell"	CL:0000895	NaiCD4Tcell	5	"CD4-positive, alpha-beta T cell"	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
-"activated CD4-positive, alpha-beta T cell"	"activated CD4-positive, alpha-beta T cell"	CL:0000896	ActCD4Tcell	5	"CD4-positive, alpha-beta T cell"	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
-"CD4-positive, alpha-beta memory T cell"	"CD4-positive, alpha-beta memory T cell"	CL:0000897	MemCD4Tcell	5	"CD4-positive, alpha-beta T cell"	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
-T-helper 17 cell	T-helper 17 cell	CL:0000899	Th17CD4Tcell	5	"CD4-positive, alpha-beta T cell"	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
-"naive thymus-derived CD8-positive, alpha-beta T cell"	"naive thymus-derived CD8-positive, alpha-beta T cell"	CL:0000900	NaiCD8Tcell	5	"CD8-positive, alpha-beta T cell"	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
-"central memory CD4-positive, alpha-beta T cell"	"central memory CD4-positive, alpha-beta T cell"	CL:0000904	CMCD4Tcell	5	"CD4-positive, alpha-beta T cell"	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
-"effector memory CD4-positive, alpha-beta T cell"	"effector memory CD4-positive, alpha-beta T cell"	CL:0000905	EMCD4Tcell	5	"CD4-positive, alpha-beta T cell"	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
-"activated CD8-positive, alpha-beta T cell"	"activated CD8-positive, alpha-beta T cell"	CL:0000906	ActCD8Tcell	5	"CD8-positive, alpha-beta T cell"	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
-"central memory CD8-positive, alpha-beta T cell"	"central memory CD8-positive, alpha-beta T cell"	CL:0000907	CMCD8Tcell	5	"CD8-positive, alpha-beta T cell"	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
-"CD8-positive, alpha-beta cytokine secreting effector T cell"	"CD8-positive, alpha-beta cytokine secreting effector T cell"	CL:0000908	CytokineCD8Tcell	5	"CD8-positive, alpha-beta T cell"	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+naive thymus-derived CD4-positive, alpha-beta T cell	naive thymus-derived CD4-positive, alpha-beta T cell	CL:0000895	NaiCD4Tcell	5	CD4-positive, alpha-beta T cell	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+activated CD4-positive, alpha-beta T cell	activated CD4-positive, alpha-beta T cell	CL:0000896	ActCD4Tcell	5	CD4-positive, alpha-beta T cell	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+CD4-positive, alpha-beta memory T cell	CD4-positive, alpha-beta memory T cell	CL:0000897	MemCD4Tcell	5	CD4-positive, alpha-beta T cell	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+T-helper 17 cell	T-helper 17 cell	CL:0000899	Th17CD4Tcell	5	CD4-positive, alpha-beta T cell	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+naive thymus-derived CD8-positive, alpha-beta T cell	naive thymus-derived CD8-positive, alpha-beta T cell	CL:0000900	NaiCD8Tcell	5	CD8-positive, alpha-beta T cell	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+central memory CD4-positive, alpha-beta T cell	central memory CD4-positive, alpha-beta T cell	CL:0000904	CMCD4Tcell	5	CD4-positive, alpha-beta T cell	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+effector memory CD4-positive, alpha-beta T cell	effector memory CD4-positive, alpha-beta T cell	CL:0000905	EMCD4Tcell	5	CD4-positive, alpha-beta T cell	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+activated CD8-positive, alpha-beta T cell	activated CD8-positive, alpha-beta T cell	CL:0000906	ActCD8Tcell	5	CD8-positive, alpha-beta T cell	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+central memory CD8-positive, alpha-beta T cell	central memory CD8-positive, alpha-beta T cell	CL:0000907	CMCD8Tcell	5	CD8-positive, alpha-beta T cell	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+CD8-positive, alpha-beta cytokine secreting effector T cell	CD8-positive, alpha-beta cytokine secreting effector T cell	CL:0000908	CytokineCD8Tcell	5	CD8-positive, alpha-beta T cell	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
 effector T cell	effector T cell	CL:0000911	EffTcell	4			T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
-"effector memory CD8-positive, alpha-beta T cell"	"effector memory CD8-positive, alpha-beta T cell"	CL:0000913	EMCD8Tcell	5	"CD8-positive, alpha-beta T cell"	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+effector memory CD8-positive, alpha-beta T cell	effector memory CD8-positive, alpha-beta T cell	CL:0000913	EMCD8Tcell	5	CD8-positive, alpha-beta T cell	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
 immature NK T cell	immature NK T cell	CL:0000914	ImmatureNKTcell	4			T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
-"CD4-positive, alpha-beta cytotoxic T cell"	"CD4-positive, alpha-beta cytotoxic T cell"	CL:0000934	CytotoxCD4Tcell	5	"CD4-positive, alpha-beta T cell"	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+CD4-positive, alpha-beta cytotoxic T cell	CD4-positive, alpha-beta cytotoxic T cell	CL:0000934	CytotoxCD4Tcell	5	CD4-positive, alpha-beta T cell	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
 pre-natural killer cell	pre-natural killer cell	CL:0000937	PreNKcell	5	natural killer cell	CL:0000623	innate lymphoid cell	CL:0001065	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
 CD56-bright cytokine secreting natural killer cell	CD56-bright cytokine secreting natural killer cell	CL:0000938	CD56brightNK	5	natural killer cell	CL:0000623	innate lymphoid cell	CL:0001065	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
 cytotoxic CD56-dim natural killer cell	cytotoxic CD56-dim natural killer cell	CL:0000939	CD56dimNK	5	natural killer cell	CL:0000623	innate lymphoid cell	CL:0001065	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
@@ -171,7 +171,7 @@ lymphocyte of B lineage	lymphocyte of B lineage	CL:0000945	Blymphocyte	2							h
 hematopoietic cell	hematopoietic cell	CL:0000988	Hematopoietic	1									cell	CL:0000548
 cerebellar granule cell	cerebellar granule cell	CL:0001031	CerebellarGranule	5	granule cell	CL:0000120	central nervous system neuron	CL:2000029	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
 bone cell	bone cell	CL:0001035	BoneCell	1									cell	CL:0000548
-"effector CD4-positive, alpha-beta T cell"	"effector CD4-positive, alpha-beta T cell"	CL:0001044	EffCD4Tcell	5	"CD4-positive, alpha-beta T cell"	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+effector CD4-positive, alpha-beta T cell	effector CD4-positive, alpha-beta T cell	CL:0001044	EffCD4Tcell	5	CD4-positive, alpha-beta T cell	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
 neoplastic cell	neoplastic cell	CL:0001063	Neoplastic	0										
 malignant cell	malignant cell	CL:0001064	Malignant	1									neoplastic cell	CL:0001063
 innate lymphoid cell	innate lymphoid cell	CL:0001065	InnateLymphoid	3					lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
@@ -263,13 +263,13 @@ cerebellum basket cell	cerebellum basket cell	CL:2000027	CerebellumBasket	5	bask
 central nervous system neuron	central nervous system neuron	CL:2000029	CNSNeuron	3					neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
 brain pericyte	brain pericyte	CL:2000043	BrainPericyte	4			central nervous system pericyte	CL:0002575	pericyte	CL:0000669	connective tissue cell	CL:0002320	cell	CL:0000548
 inflammatory monocyte		DB:0000001	InflamMonocyte	4			monocyte	CL:0000576	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
-"exhausted-like CD4-positive, alpha-beta T cell"		DB:0000002	ExhCD4Tcell	5	"CD4-positive, alpha-beta T cell"	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
-"proliferating CD8-positive, alpha-beta T cell"		DB:0000003	ProlifCD8Tcell	5	"CD8-positive, alpha-beta T cell"	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+exhausted-like CD4-positive, alpha-beta T cell		DB:0000002	ExhCD4Tcell	5	CD4-positive, alpha-beta T cell	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+proliferating CD8-positive, alpha-beta T cell		DB:0000003	ProlifCD8Tcell	5	CD8-positive, alpha-beta T cell	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
 CCR7-positive myeloid dendritic cell		DB:0000004	cDC_CCR7	4			myeloid dendritic cell	CL:0000782	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
-"exhausted-like CD8-positive, alpha-beta T cell"		DB:0000005	ExhCD8Tcell	5	"CD8-positive, alpha-beta T cell"	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+exhausted-like CD8-positive, alpha-beta T cell		DB:0000005	ExhCD8Tcell	5	CD8-positive, alpha-beta T cell	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
 melanocytic melanoma cell		DB:0000006	MelMelanoma	2							malignant cell	CL:0001064	neoplastic cell	CL:0001063
-"IL7R-max CD8-positive, alpha-beta cytotoxic T cell"		DB:0000007	CD8Tcell_IL7Rmax	5	"CD8-positive, alpha-beta T cell"	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
-"IL7R-max CD4-positive, alpha-beta cytotoxic T cell"		DB:0000040	CD4Tcell_IL7Rmax	5	"CD4-positive, alpha-beta T cell"	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+IL7R-max CD8-positive, alpha-beta cytotoxic T cell		DB:0000007	CD8Tcell_IL7Rmax	5	CD8-positive, alpha-beta T cell	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+IL7R-max CD4-positive, alpha-beta cytotoxic T cell		DB:0000040	CD4Tcell_IL7Rmax	5	CD4-positive, alpha-beta T cell	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
 doublet		DB:0000008	Doublet	1									cell	CL:0000548
 immature enterocyte		DB:0000009	ImmatureEnterocyte	5	enterocyte	CL:0000584	intestinal epithelial cell	CL:0002563	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	cell	CL:0000548
 immature goblet cell		DB:0000010	ImmatureGoblet	4			goblet cell	CL:0000160	glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	cell	CL:0000548
@@ -283,7 +283,7 @@ nonhematopoeitic cell		DB:0000017	NonHematopoeitic	1									cell	CL:0000548
 proliferating B cell		DB:0000018	ProlifBcell	4			B cell	CL:0000236	lymphocyte of B lineage	CL:0000945	hematopoietic cell	CL:0000988	cell	CL:0000548
 proliferating monocyte		DB:0000020	ProlifMonocyte	4			monocyte	CL:0000576	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
 proliferating T cell		DB:0000021	ProlifTcell	4			T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
-"proliferating CD4-positive, alpha-beta T cell"		DB:0000022	ProlifCD4Tcell	5	"CD4-positive, alpha-beta T cell"	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+proliferating CD4-positive, alpha-beta T cell		DB:0000022	ProlifCD4Tcell	5	CD4-positive, alpha-beta T cell	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
 proliferating transit amplifying cell		DB:0000023	ProlifTAmplifying	5	transit amplifying cell	DB:0000024	intestinal epithelial cell	CL:0002563	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	cell	CL:0000548
 transit amplifying cell		CL:0009010	TAmplifying	4			intestinal epithelial cell	CL:0002563	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	cell	CL:0000548
 SLC17A7-positive neuron		DB:0000025	Neuron_SLC17A7	4			glutamatergic neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
@@ -307,7 +307,7 @@ U-87 MG	U-87 MG	EFO:0005237	U87MG	2							epithelial cell derived cell line	EFO:
 embryonic cell	embryonic cell	CL:0002321	Embryonic	1									cell	CL:0000548
 immature conventional dendritic cell	immature conventional dendritic cell	CL:0000840	ImmaturecDC	4			myeloid dendritic cell	CL:0002394	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
 activated T cell		DB:0000043	ActTcell	4			T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
-"CD8-positive, alpha-beta memory T cell"	"CD8-positive, alpha-beta memory T cell"	CL:0000909	MemCD8Tcell	5	"CD8-positive, alpha-beta T cell"	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+CD8-positive, alpha-beta memory T cell	CD8-positive, alpha-beta memory T cell	CL:0000909	MemCD8Tcell	5	CD8-positive, alpha-beta T cell	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
 group 1 innate lymphoid cell	group 1 innate lymphoid cell	CL:0001067	ILC1	4			innate lymphoid cell	CL:0001065	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
 group 2 innate lymphoid cell	group 2 innate lymphoid cell	CL:0001069	ILC2	4			innate lymphoid cell	CL:0001065	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
 group 3 innate lymphoid cell	group 3 innate lymphoid cell	CL:0001071	ILC3	4			innate lymphoid cell	CL:0001065	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
@@ -345,7 +345,7 @@ ACE-positive macrophage		DB:0000078	Macrophage_ACE	4			macrophage	CL:0000235	mye
 FOLR2-positive macrophage		DB:0000079	Macrophage_FOLR2	4			macrophage	CL:0000235	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
 TREM2-positive macrophage		DB:0000080	Macrophage_TREM2	4			macrophage	CL:0000235	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
 RXRG-positive macrophage		DB:0000081	Macrophage_RXRG	4			macrophage	CL:0000235	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
-"CD8-positive, alpha-beta resource T cell"		DB:0000082	ResourceCD8Tcell	5	"CD8-positive, alpha-beta T cell"	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+CD8-positive, alpha-beta resource T cell		DB:0000082	ResourceCD8Tcell	5	CD8-positive, alpha-beta T cell	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
 monocyte or dendritic cell		DB:0000083	MonocyteDC	3					myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
 CD209-positive myeloid dendritic cell		DB:0000084	cDC_CD209	4			myeloid dendritic cell	CL:0000782	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
 cardiac endothelial cell	cardiac endothelial cell	CL:0010008	CardialEndothelial	2							endothelial cell	CL:0000115	cell	CL:0000548
@@ -391,8 +391,8 @@ epicardial adipocyte	epicardial adipocyte	CL:1000309	EpicardialAdipocyte	3					f
 Slamf1-positive multipotent progenitor cell	Slamf1-positive multipotent progenitor cell	CL:0002036	MultipotentPC_SLAMF	4			hematopoietic multipotent progenitor cell	CL:0000837	hematopoietic precursor cell	CL:0008001	hematopoietic cell	CL:0000988	cell	CL:0000548
 proliferating natural killer cell		DB:0000086	ProlifNKcell	5	natural killer cell	CL:0000623	innate lymphoid cell	CL:0001065	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
 B myeloid cell doublet		DB:0000087	BMyeloid	2							hematopoietic cell	CL:0000988	cell	CL:0000548
-"BEST4+ intestinal epithelial cell, human"	"BEST4+ intestinal epithelial cell, human"	CL:4030026	BEST4enterocyte	5	enterocyte	CL:0000584	intestinal epithelial cell	CL:0002563	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	cell	CL:0000548
-T follicular helper cell	T follicular helper cell	CL:0002038	FollicularTh	5	"CD4-positive, alpha-beta T cell"	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+BEST4+ intestinal epithelial cell, human	BEST4+ intestinal epithelial cell, human	CL:4030026	BEST4enterocyte	5	enterocyte	CL:0000584	intestinal epithelial cell	CL:0002563	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	cell	CL:0000548
+T follicular helper cell	T follicular helper cell	CL:0002038	FollicularTh	5	CD4-positive, alpha-beta T cell	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
 capillary endothelial cell	capillary endothelial cell	CL:0002144	CapillaryEndothelial	4			blood vessel endothelial cell	CL:0000071	endothelial cell of vascular tree	CL:0002139	endothelial cell	CL:0000115	cell	CL:0000548
 colon macrophage	colon macrophage	CL:0009038	ColonMacrophage	4			macrophage	CL:0000235	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
 endothelial cell of artery	endothelial cell of artery	CL:1000413	EndothelialArtery	4			blood vessel endothelial cell	CL:0000071	endothelial cell of vascular tree	CL:0002139	endothelial cell	CL:0000115	cell	CL:0000548

--- a/besca/datasets/nomenclature/CellTypes_v1.tsv
+++ b/besca/datasets/nomenclature/CellTypes_v1.tsv
@@ -1,506 +1,512 @@
 dblabel	dblabelEFO	EFO	short_dblabel	is_level	l4	l4EFO	l3	l3EFO	l2	l2EFO	l1	l1EFO	l0	l0EFO
-Use this one for labelling	identical to dblabel if EFO term present	EFO ID if present, otherwise internal DB ID	Used only for plotting; should also be unique & consistent	hierarchy level										
+Use this one for labelling	identical to dblabel if EFO term present	"EFO ID if present, otherwise internal DB ID"	Used only for plotting; should also be unique & consistent	hierarchy level										
 cultured cell	cultured cell	CL:0000010	Cultured	0										
-germ line stem cell	germ line stem cell	CL:0000014	GermLineStem	3					stem cell	CL:0000034	precursor cell	CL:0011115	animal cell	CL:0000548
-male germ line stem cell	male germ line stem cell	CL:0000016	MaleGerm	4			germ line stem cell	CL:0000014	stem cell	CL:0000034	precursor cell	CL:0011115	animal cell	CL:0000548
-spermatocyte	spermatocyte	CL:0000017	Spermatocyte	5	male germ line stem cell	CL:0000016	germ line stem cell	CL:0000014	stem cell	CL:0000034	precursor cell	CL:0011115	animal cell	CL:0000548
-spermatid	spermatid	CL:0000018	Spermatid	5	male germ line stem cell	CL:0000016	germ line stem cell	CL:0000014	stem cell	CL:0000034	precursor cell	CL:0011115	animal cell	CL:0000548
-sperm	sperm	CL:0000019	Sperm	5	male germ line stem cell	CL:0000016	germ line stem cell	CL:0000014	stem cell	CL:0000034	precursor cell	CL:0011115	animal cell	CL:0000548
-stem cell	stem cell	CL:0000034	Stem	2							precursor cell	CL:0011115	animal cell	CL:0000548
-epithelial fate stem cell	epithelial fate stem cell	CL:0000036	EpithelialStem	4			somatic stem cell	CL:0000723	stem cell	CL:0000034	precursor cell	CL:0011115	animal cell	CL:0000548
-hematopoietic stem cell	hematopoietic stem cell	CL:0000037	HematoStem	4			hematopoietic stem cell	CL:0000037	hematopoietic precursor cell	CL:0008001	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-neuronal stem cell	neuronal stem cell	CL:0000047	NeuronalStem	4			multi fate stem cell	CL:0000048	stem cell	CL:0000034	precursor cell	CL:0011115	animal cell	CL:0000548
-multi fate stem cell	multi fate stem cell	CL:0000048	MultiFateStem	3					stem cell	CL:0000034	precursor cell	CL:0011115	animal cell	CL:0000548
-common myeloid progenitor	common myeloid progenitor	CL:0000049	CommonMyeloidPC	3					hematopoietic precursor cell	CL:0008001	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-megakaryocyte-erythroid progenitor cell	megakaryocyte-erythroid progenitor cell	CL:0000050	MegakaryoErythroidPC	3					hematopoietic precursor cell	CL:0008001	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-common lymphoid progenitor	common lymphoid progenitor	CL:0000051	CommonLymphoidPC	3					hematopoietic precursor cell	CL:0008001	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-fibroblast	fibroblast	CL:0000057	Fibroblast	2							connective tissue cell	CL:0002320	animal cell	CL:0000548
-osteoblast	osteoblast	CL:0000062	Osteoblast	2							connective tissue cell	CL:0002320	animal cell	CL:0000548
-ependymal cell	ependymal cell	CL:0000065	Ependymal	3					ciliated epithelial cell	CL:0000067	epithelial cell	CL:0000066	animal cell	CL:0000548
-epithelial cell	epithelial cell	CL:0000066	Epithelial	1									animal cell	CL:0000548
-ciliated epithelial cell	ciliated epithelial cell	CL:0000067	CiliatedEpithelial	2							epithelial cell	CL:0000066	animal cell	CL:0000548
-duct epithelial cell	duct epithelial cell	CL:0000068	DuctEpithelial	2							epithelial cell	CL:0000066	animal cell	CL:0000548
-branched duct epithelial cell	branched duct epithelial cell	CL:0000069	BranchedDuctEpith	3					duct epithelial cell	CL:0000068	epithelial cell	CL:0000066	animal cell	CL:0000548
-blood vessel endothelial cell	blood vessel endothelial cell	CL:0000071	VesselEndothelial	3					endothelial cell of vascular tree	CL:0002139	endothelial cell	CL:0000115	animal cell	CL:0000548
-epithelial cell of lung	epithelial cell of lung	CL:0000082	LungEpithelial	2							epithelial cell	CL:0000066	animal cell	CL:0000548
-T cell	T cell	CL:0000084	Tcell	3					lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-Kupffer cell	Kupffer cell	CL:0000091	Kupffer	4			macrophage	CL:0000235	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-granulocyte	granulocyte	CL:0000094	Granulocyte	3					myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-mast cell	mast cell	CL:0000097	Mast	3					myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-interneuron	interneuron	CL:0000099	Interneuron	3					neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-bipolar neuron	bipolar neuron	CL:0000103	BipolarN	3					neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-cholinergic neuron	cholinergic neuron	CL:0000108	CholinergicN	3					neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-endothelial cell	endothelial cell	CL:0000115	Endothelial	1									animal cell	CL:0000548
-basket cell	basket cell	CL:0000118	Basket	4			central nervous system neuron	CL:2000029	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-granule cell	granule cell	CL:0000120	Granule	4			central nervous system neuron	CL:2000029	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-Purkinje cell	Purkinje cell	CL:0000121	Purkinje	4			central nervous system neuron	CL:2000029	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-glial cell	glial cell	CL:0000125	Glial	2							neural cell	CL:0002319	animal cell	CL:0000548
-macroglial cell	macroglial cell	CL:0000126	Macroglial	3					glial cell	CL:0000125	neural cell	CL:0002319	animal cell	CL:0000548
-astrocyte	astrocyte	CL:0000127	Astrocyte	4			macrogial cell	CL:0000126	glial cell	CL:0000125	neural cell	CL:0002319	animal cell	CL:0000548
-oligodendrocyte	oligodendrocyte	CL:0000128	Oligodendrocyte	4			macrogial cell	CL:0000126	glial cell	CL:0000125	neural cell	CL:0002319	animal cell	CL:0000548
-microglial cell	microglial cell	CL:0000129	Microglial	5	central nervous system macrophage	CL:0000878	macrophage	CL:0000235	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-mesenchymal stem cell	mesenchymal stem cell	CL:0000134	MesenchymalStem	4			multi fate stem cell	CL:0000048	stem cell	CL:0000034	precursor cell	CL:0011115	animal cell	CL:0000548
-pigment cell	pigment cell	CL:0000147	Pigment	2							epithelial cell	CL:0000066	animal cell	CL:0000548
-glandular epithelial cell	glandular epithelial cell	CL:0000150	GlandularEpithelial	2							epithelial cell	CL:0000066	animal cell	CL:0000548
-secretory cell	secretory cell	CL:0000151	Secretory	1									animal cell	CL:0000548
-club cell	club cell	CL:0000158	Club	5	bronchial epithelial cell	CL:0002328	respiratory epithelial cell	CL:0002368	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	animal cell	CL:0000548
-goblet cell	goblet cell	CL:0000160	Goblet	3					glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	animal cell	CL:0000548
-endocrine cell	endocrine cell	CL:0000163	Endocrine	2							secretory cell	CL:0000151	animal cell	CL:0000548
-enteroendocrine cell	enteroendocrine cell	CL:0000164	Enteroendocrine	3					glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	animal cell	CL:0000548
-neuroendocrine cell	neuroendocrine cell	CL:0000165	Neuroendocrine	3					endocrine cell	CL:0000163	secretory cell	CL:0000151	animal cell	CL:0000548
-type B pancreatic cell	type B pancreatic cell	CL:0000169	BetaPancreatic	5	pancreatic endocrine cell	CL:0008024	enteroendocrine cell	CL:0000164	glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	animal cell	CL:0000548
-pancreatic A cell	pancreatic A cell	CL:0000171	AlphaPancreatic	5	pancreatic endocrine cell	CL:0008024	enteroendocrine cell	CL:0000164	glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	animal cell	CL:0000548
-pancreatic D cell	pancreatic D cell	CL:0000173	DeltaPancreatic	5	pancreatic endocrine cell	CL:0008024	enteroendocrine cell	CL:0000164	glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	animal cell	CL:0000548
-Leydig cell	Leydig cell	CL:0000178	Leydig	2							secretory cell	CL:0000151	animal cell	CL:0000548
-hepatocyte	hepatocyte	CL:0000182	Hepatocyte	2							epithelial cell	CL:0000066	animal cell	CL:0000548
-contractile cell	contractile cell	CL:0000183	Contractile	1									animal cell	CL:0000548
-myofibroblast cell	myofibroblast cell	CL:0000186	Myofibroblast	2							contractile cell	CL:0000183	animal cell	CL:0000548
-muscle cell	muscle cell	CL:0000187	MuscleCell	2							contractile cell	CL:0000183	animal cell	CL:0000548
-smooth muscle cell	smooth muscle cell	CL:0000192	SmoothMuscle	3					muscle cell	CL:0000187	contractile cell	CL:0000183	animal cell	CL:0000548
-photoreceptor cell	photoreceptor cell 	CL:0000210	Photoreceptor	4			sensory neuron	CL:0000128	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-Sertoli cell	Sertoli cell	CL:0000216	Sertoli	2							epithelial cell	CL:0000066	animal cell	CL:0000548
-myelinating Schwann cell	myelinating Schwann cell	CL:0000218	MyelinSchwann	4			Schwann cell	CL:0002573	glial cell	CL:0000125	neural cell	CL:0002319	animal cell	CL:0000548
-erythrocyte	erythrocyte	CL:0000232	Erythrocyte	3					erythroid lineage cell	CL:0000764	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-macrophage	macrophage	CL:0000235	Macrophage	3					myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-B cell	B cell	CL:0000236	Bcell	3					lymphocyte of B lineage	CL:0000945	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-tracheal epithelial cell	tracheal epithelial cell	CL:0000307	TrachealEpithelial	4			respiratory epithelial cell	CL:0002368	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	animal cell	CL:0000548
-keratinocyte	keratinocyte	CL:0000312	Keratinocyte	4			epidermal cell	CL:0000362	ecto-epithelial cell	CL:0002077	epithelial cell	CL:0000066	animal cell	CL:0000548
-pneumocyte	pneumocyte	CL:0000322	Pneumocyte	3					epithelial cell of lung	CL:0000082	epithelial cell	CL:0000066	animal cell	CL:0000548
-epidermal cell	epidermal cell	CL:0000362	Epidermal	3					ecto-epithelial cell	CL:0002077	epithelial cell	CL:0000066	animal cell	CL:0000548
-Langerhans cell	Langerhans cell	CL:0000453	Langerhans	4			myeloid dendritic cell	CL:0000782	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-CD4-positive helper T cell	CD4-positive helper T cell	CL:0000492	ThCD4Tcell	5	CD4-positive, alpha-beta T cell	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-stromal cell	stromal cell	CL:0000499	Stromal	2							connective tissue cell	CL:0002320	animal cell	CL:0000548
-paneth cell	paneth cell	CL:0000510	Paneth	4			intestinal epithelial cell	CL:0002563	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	animal cell	CL:0000548
-neuron	neuron	CL:0000540	Neuron	3							neural cell	CL:0002319	animal cell	CL:0000540
-lymphocyte	lymphocyte	CL:0000542	Lymphocyte	2							hematopoietic cell	CL:0000988	animal cell	CL:0000548
-T-helper 1 cell	T-helper 1 cell	CL:0000545	Th1CD4Tcell	5	CD4-positive, alpha-beta T cell	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-proerythroblast	proerythroblast	CL:0000547	Proerythroblast	3					erythroid lineage cell	CL:0000764	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-animal cell	animal cell	CL:0000548	Cell	0										
-megakaryocyte	megakaryocyte	CL:0000556	Megakaryocyte	2							hematopoietic cell	CL:0000988	animal cell	CL:0000548
-granulocyte monocyte progenitor cell	granulocyte monocyte progenitor cell	CL:0000557	GranuloMonocytePC	3					hematopoietic precursor cell	CL:0008001	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-promonocyte	promonocyte	CL:0000559	Promonocyte	3					hematopoietic precursor cell	CL:0008001	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-amacrine cell	amacrine cell	CL:0000561	Amacrine	2							neural cell	CL:0002319	animal cell	CL:0000548
-retinal cone cell	retinal cone cell	CL:0000573	RetinalCone	5	photoreceptor cell	CL:0000210	sensory neuron	CL:0000128	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-monocyte	monocyte	CL:0000576	Monocyte	3					myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-alveolar macrophage	alveolar macrophage	CL:0000583	AlvelolarMacrophage	5	lung macrophage	CL:1001603	macrophage	CL:0000235	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-enterocyte	enterocyte	CL:0000584	Enterocyte	4			intestinal epithelial cell	CL:0002563	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	animal cell	CL:0000548
-skeletal muscle satellite cell	skeletal muscle satellite cell	CL:0000594	MuscleSatellite	3					muscle precursor cell	CL:0000680	precursor cell	CL:0011115	animal cell	CL:0000548
-pyramidal neuron	pyramidal neuron	CL:0000598	Pyramidal	3					neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-retinal rod cell	retinal rod cell	CL:0000604	RetinalRod	5	photoreceptor cell	CL:0000210	sensory neuron	CL:0000128	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-GABAergic neuron	GABAergic neuron	CL:0000617	GABAergicN	3					neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-acinar cell	acinar cell	CL:0000622	Acinar	3					glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	animal cell	CL:0000548
-natural killer cell	natural killer cell	CL:0000623	NKcell	4			innate lymphoid cell	CL:0001065	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-CD4-positive, alpha-beta T cell	CD4-positive, alpha-beta T cell	CL:0000624	CD4Tcell	4			T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-CD8-positive, alpha-beta T cell	CD8-positive, alpha-beta T cell	CL:0000625	CD8Tcell	4			T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-Mueller cell	Mueller cell	CL:0000636	Mueller	5	astrocyte	CL:0000127	macrogial cell	CL:0000126	glial cell	CL:0000125	neural cell	CL:0002319	animal cell	CL:0000548
-Bergmann glial cell	Bergmann glial cell	CL:0000644	BergmannGlial	5	astrocyte	CL:0000127	macrogial cell	CL:0000126	glial cell	CL:0000125	neural cell	CL:0002319	animal cell	CL:0000548
-basal cell	basal cell	CL:0000646	Basal	5	epithelial fate stem cell	CL:0000036	somatic stem cell	CL:0000723	stem cell	CL:0000034	precursor cell	CL:0011115	animal cell	CL:0000548
-mesangial cell	mesangial cell	CL:0000650	Mesangial	3					pericyte	CL:0000669	connective tissue cell	CL:0002320	animal cell	CL:0000548
-pericyte	pericyte	CL:0000669	Pericyte	2							connective tissue cell	CL:0002320	animal cell	CL:0000548
-glutamatergic neuron	glutamatergic neuron	CL:0000679	GlutamatergicN	3					neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-muscle precursor cell	muscle precursor cell	CL:0000680	MusclePC	2							precursor cell	CL:0011115	animal cell	CL:0000548
-radial glial cell	radial glial cell	CL:0000681	RadialGlial	3					glial cell	CL:0000125	neural cell	CL:0002319	animal cell	CL:0000548
-microfold cell	M cell of gut	CL:0000682	McellGut	3					endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	animal cell	CL:0000548
-Cajal-Retzius cell	Cajal-Retzius cell	CL:0000695	CajalRetzius	4			central nervous system neuron	CL:2000029	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-PP cell	PP cell	CL:0000696	PPcell	4			enteroendocrine cell	CL:0000164	glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	animal cell	CL:0000548
-dopaminergic neuron	dopaminergic neuron	CL:0000700	DopaminergicN	3					neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-endothelial tip cell	endothelial tip cell	CL:0000704	TipEndothelial	4			blood vessel endothelial cell	CL:0000071	endothelial cell of vascular tree	CL:0002139	endothelial cell	CL:0000115	animal cell	CL:0000548
-leptomeningeal cell	leptomeningeal cell	CL:0000708	Leptomeningeal	2							neural cell	CL:0002319	animal cell	CL:0000548
-somatic stem cell	somatic stem cell	CL:0000723	SomaticStem	3					stem cell	CL:0000034	precursor cell	CL:0011115	animal cell	CL:0000548
-striated muscle cell	striated muscle cell	CL:0000737	StriatedMuscle	3					muscle cell	CL:0000187	contractile cell	CL:0000183	animal cell	CL:0000548
-leukocyte	leukocyte	CL:0000738	Leukocyte	2							hematopoietic cell	CL:0000988	animal cell	CL:0000548
-retinal ganglion cell	retinal ganglion cell	CL:0000740	RetinalGanglion	4			central nervous system neuron	CL:2000029	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-retina horizontal cell	retina horizontal cell	CL:0000745	RetinalHorizontal	4			interneuron	CL:0000099	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-cardiac muscle cell	cardiac muscle cell	CL:0000746	CardiacMuscle	4			striated muscle cell	CL:0000737	muscle cell	CL:0000187	contractile cell	CL:0000183	animal cell	CL:0000548
-retinal bipolar neuron	retinal bipolar neuron	CL:0000748	RetinalBPNeuron	4			bipolar neuron	CL:0000103	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-OFF-bipolar cell	OFF-bipolar cell	CL:0000750	OFFBipolar	5	retinal bipolar neuron	CL:0000748	bipolar neuron	CL:0000103	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-ON-bipolar cell	ON-bipolar cell	CL:0000749	ONBipolar	5	retinal bipolar neuron	CL:0000748	bipolar neuron	CL:0000103	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-rod bipolar cell	rod bipolar cell	CL:0000751	RodBipolar	5	retinal bipolar neuron	CL:0000748	bipolar neuron	CL:0000103	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-cone retinal bipolar cell	cone retinal bipolar cell	CL:0000752	ConeBipolar	5	retinal bipolar neuron	CL:0000748	bipolar neuron	CL:0000103	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-nucleated thrombocyte	nucleated thrombocyte	CL:0000762	NucleatedThrombocyte	3					myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-erythroid lineage cell	erythroid lineage cell	CL:0000764	Erythroid	2							hematopoietic cell	CL:0000988	animal cell	CL:0000548
-erythroblast	erythroblast	CL:0000765	Erythroblast	3					erythroid lineage cell	CL:0000764	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-myeloid leukocyte	myeloid leukocyte	CL:0000766	Myeloid	2							hematopoietic cell	CL:0000988	animal cell	CL:0000548
-basophil	basophil	CL:0000767	Basophil	4			granulocyte	CL:0000094	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-eosinophil	eosinophil	CL:0000771	Eosinophil	4			granulocyte	CL:0000094	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-neutrophil	neutrophil	CL:0000775	Neutrophil	4			granulocyte	CL:0000094	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-myeloid dendritic cell	myeloid dendritic cell	CL:0000782	cDC	3					myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-plasmacytoid dendritic cell	plasmacytoid dendritic cell	CL:0000784	pDC	3					lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-plasma cell	plasma cell	CL:0000786	Plasma	3					lymphocyte of B lineage	CL:0000945	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-memory B cell	memory B cell	CL:0000787	MemBcell	4			B cell	CL:0000236	lymphocyte of B lineage	CL:0000945	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-naive B cell	naive B cell	CL:0000788	NaiBcell	4			B cell	CL:0000236	lymphocyte of B lineage	CL:0000945	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-CD8-positive, alpha-beta cytotoxic T cell	CD8-positive, alpha-beta cytotoxic T cell	CL:0000794	CytotoxCD8Tcell	5	CD8-positive, alpha-beta T cell	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-gamma-delta T cell	gamma-delta T cell	CL:0000798	gdTcell	4			T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-memory T cell	memory T cell	CL:0000813	MemTcell	4			T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-mature NK T cell	mature NK T cell	CL:0000814	NKTcell	4			T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-regulatory T cell	regulatory T cell	CL:0000815	RegTcell	4			T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-immature B cell	immature B cell	CL:0000816	ImmatureBcell	4			B cell	CL:0000236	lymphocyte of B lineage	CL:0000945	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-precursor B cell	precursor B cell	CL:0000817	BcellPC	4			B cell	CL:0000236	lymphocyte of B lineage	CL:0000945	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-immature natural killer cell	immature natural killer cell	CL:0000823	ImmatureNK	5	natural killer cell	CL:0000623	innate lymphoid cell	CL:0001065	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-pro-B cell	pro-B cell	CL:0000826	ProBcell	3					lymphoid lineage restricted progenitor cell	CL:0000838 	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-pro-T cell	pro-T cell	CL:0000827	ProTcell	3					lymphoid lineage restricted progenitor cell	CL:0000838 	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-hematopoietic multipotent progenitor cell	hematopoietic multipotent progenitor cell	CL:0000837 	HematoMultipotentPC	3					hematopoietic precursor cell	CL:0008001	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-lymphoid lineage restricted progenitor cell	lymphoid lineage restricted progenitor cell	CL:0000838 	LymphoidPC	2							hematopoietic cell	CL:0000988	animal cell	CL:0000548
-myeloid lineage restricted progenitor cell	myeloid lineage restricted progenitor cell	CL:0000839	MyeloidPC	3					hematopoietic precursor cell	CL:0008001	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-follicular B cell	follicular B cell	CL:0000843	FollicularBcell	4			B cell	CL:0000236	lymphocyte of B lineage	CL:0000945	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-germinal center B cell	germinal center B cell	CL:0000844	GermCenterBcell	4			B cell	CL:0000236	lymphocyte of B lineage	CL:0000945	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-classical monocyte	classical monocyte	CL:0000860	ClassMonocyte	4			monocyte	CL:0000576	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-non-classical monocyte	non-classical monocyte	CL:0000875	NClassMonocyte	4			monocyte	CL:0000576	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-central nervous system macrophage	central nervous system macrophage	CL:0000878	CNSMacrophage	4			macrophage	CL:0000235	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-perivascular macrophage	perivascular macrophage	CL:0000881	PerivascMacrophage	5	central nervous system macrophage	CL:0000878	macrophage	CL:0000235	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-DN1 thymic pro-T cell	DN1 thymic pro-T cell	CL:0000894	DN1ProTcell	4			pro-T cell	CL:0000827	lymphoid lineage restricted progenitor cell	CL:0000838 	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-naive thymus-derived CD4-positive, alpha-beta T cell	naive thymus-derived CD4-positive, alpha-beta T cell	CL:0000895	NaiCD4Tcell	5	CD4-positive, alpha-beta T cell	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-activated CD4-positive, alpha-beta T cell	activated CD4-positive, alpha-beta T cell	CL:0000896	ActCD4Tcell	5	CD4-positive, alpha-beta T cell	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-CD4-positive, alpha-beta memory T cell	CD4-positive, alpha-beta memory T cell	CL:0000897	MemCD4Tcell	5	CD4-positive, alpha-beta T cell	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-T-helper 17 cell	T-helper 17 cell	CL:0000899	Th17CD4Tcell	5	CD4-positive, alpha-beta T cell	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-naive thymus-derived CD8-positive, alpha-beta T cell	naive thymus-derived CD8-positive, alpha-beta T cell	CL:0000900	NaiCD8Tcell	5	CD8-positive, alpha-beta T cell	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-central memory CD4-positive, alpha-beta T cell	central memory CD4-positive, alpha-beta T cell	CL:0000904	CMCD4Tcell	5	CD4-positive, alpha-beta T cell	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-effector memory CD4-positive, alpha-beta T cell	effector memory CD4-positive, alpha-beta T cell	CL:0000905	EMCD4Tcell	5	CD4-positive, alpha-beta T cell	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-activated CD8-positive, alpha-beta T cell	activated CD8-positive, alpha-beta T cell	CL:0000906	ActCD8Tcell	5	CD8-positive, alpha-beta T cell	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-central memory CD8-positive, alpha-beta T cell	central memory CD8-positive, alpha-beta T cell	CL:0000907	CMCD8Tcell	5	CD8-positive, alpha-beta T cell	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-CD8-positive, alpha-beta cytokine secreting effector T cell	CD8-positive, alpha-beta cytokine secreting effector T cell	CL:0000908	CytokineCD8Tcell	5	CD8-positive, alpha-beta T cell	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-effector T cell	effector T cell	CL:0000911	EffTcell	4			T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-effector memory CD8-positive, alpha-beta T cell	effector memory CD8-positive, alpha-beta T cell	CL:0000913	EMCD8Tcell	5	CD8-positive, alpha-beta T cell	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-immature NK T cell	immature NK T cell	CL:0000914	ImmatureNKTcell	4			T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-CD4-positive, alpha-beta cytotoxic T cell	CD4-positive, alpha-beta cytotoxic T cell	CL:0000934	CytotoxCD4Tcell	5	CD4-positive, alpha-beta T cell	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-pre-natural killer cell	pre-natural killer cell	CL:0000937	PreNKcell	5	natural killer cell	CL:0000623	innate lymphoid cell	CL:0001065	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-CD56-bright cytokine secreting natural killer cell	CD56-bright cytokine secreting natural killer cell	CL:0000938	CD56brightNK	5	natural killer cell	CL:0000623	innate lymphoid cell	CL:0001065	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-cytotoxic CD56-dim natural killer cell	cytotoxic CD56-dim natural killer cell	CL:0000939	CD56dimNK	5	natural killer cell	CL:0000623	innate lymphoid cell	CL:0001065	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-mucosal invariant T cell	mucosal invariant T cell	CL:0000940	MAIT	4			T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-lymphocyte of B lineage	lymphocyte of B lineage	CL:0000945	Blymphocyte	2							hematopoietic cell	CL:0000988	animal cell	CL:0000548
-hematopoietic cell	hematopoietic cell	CL:0000988	Hematopoietic	0									animal cell	CL:0000548
-cerebellar granule cell	cerebellar granule cell	CL:0001031	CerebellarGranule	5	granule cell	CL:0000120	central nervous system neuron	CL:2000029	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-bone cell	bone cell	CL:0001035	BoneCell	1									animal cell	CL:0000548
-effector CD4-positive, alpha-beta T cell	effector CD4-positive, alpha-beta T cell	CL:0001044	EffCD4Tcell	5	CD4-positive, alpha-beta T cell	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
+germ line stem cell	germ line stem cell	CL:0000014	GermLineStem	3					stem cell	CL:0000034	precursor cell	CL:0011115	cell	CL:0000548
+male germ line stem cell	male germ line stem cell	CL:0000016	MaleGerm	4			germ line stem cell	CL:0000014	stem cell	CL:0000034	precursor cell	CL:0011115	cell	CL:0000548
+spermatocyte	spermatocyte	CL:0000017	Spermatocyte	5	male germ line stem cell	CL:0000016	germ line stem cell	CL:0000014	stem cell	CL:0000034	precursor cell	CL:0011115	cell	CL:0000548
+spermatid	spermatid	CL:0000018	Spermatid	5	male germ line stem cell	CL:0000016	germ line stem cell	CL:0000014	stem cell	CL:0000034	precursor cell	CL:0011115	cell	CL:0000548
+sperm	sperm	CL:0000019	Sperm	5	male germ line stem cell	CL:0000016	germ line stem cell	CL:0000014	stem cell	CL:0000034	precursor cell	CL:0011115	cell	CL:0000548
+stem cell	stem cell	CL:0000034	Stem	2							precursor cell	CL:0011115	cell	CL:0000548
+epithelial fate stem cell	epithelial fate stem cell	CL:0000036	EpithelialStem	4			somatic stem cell	CL:0000723	stem cell	CL:0000034	precursor cell	CL:0011115	cell	CL:0000548
+hematopoietic stem cell	hematopoietic stem cell	CL:0000037	HematoStem	3					hematopoietic precursor cell	CL:0008001	hematopoietic cell	CL:0000988	cell	CL:0000548
+neuronal stem cell	neuronal stem cell	CL:0000047	NeuronalStem	4			multi fate stem cell	CL:0000048	stem cell	CL:0000034	precursor cell	CL:0011115	cell	CL:0000548
+multi fate stem cell	multi fate stem cell	CL:0000048	MultiFateStem	3					stem cell	CL:0000034	precursor cell	CL:0011115	cell	CL:0000548
+common myeloid progenitor	common myeloid progenitor	CL:0000049	CommonMyeloidPC	3					hematopoietic precursor cell	CL:0008001	hematopoietic cell	CL:0000988	cell	CL:0000548
+megakaryocyte-erythroid progenitor cell	megakaryocyte-erythroid progenitor cell	CL:0000050	MegakaryoErythroidPC	3					hematopoietic precursor cell	CL:0008001	hematopoietic cell	CL:0000988	cell	CL:0000548
+common lymphoid progenitor	common lymphoid progenitor	CL:0000051	CommonLymhpoidPC	3					hematopoietic precursor cell	CL:0008001	hematopoietic cell	CL:0000988	cell	CL:0000548
+fibroblast	fibroblast	CL:0000057	Fibroblast	2							connective tissue cell	CL:0002320	cell	CL:0000548
+osteoblast	osteoblast	CL:0000062	Osteoblast	2							connective tissue cell	CL:0002320	cell	CL:0000548
+ependymal cell	ependymal cell	CL:0000065	Ependymal	3					ciliated epithelial cell	CL:0000067	epithelial cell	CL:0000066	cell	CL:0000548
+epithelial cell	epithelial cell	CL:0000066	Epithelial	1									cell	CL:0000548
+ciliated epithelial cell	ciliated epithelial cell	CL:0000067	CiliatedEpithelial	2							epithelial cell	CL:0000066	cell	CL:0000548
+duct epithelial cell	duct epithelial cell	CL:0000068	DuctEpithelial	2							epithelial cell	CL:0000066	cell	CL:0000548
+branched duct epithelial cell	branched duct epithelial cell	CL:0000069	BranchedDuctEpith	3					duct epithelial cell	CL:0000068	epithelial cell	CL:0000066	cell	CL:0000548
+blood vessel endothelial cell	blood vessel endothelial cell	CL:0000071	VesselEndothelial	3					endothelial cell of vascular tree	CL:0002139	endothelial cell	CL:0000115	cell	CL:0000548
+epithelial cell of lung	epithelial cell of lung	CL:0000082	LungEpithelial	2							epithelial cell	CL:0000066	cell	CL:0000548
+T cell	T cell	CL:0000084	Tcell	3					lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+Kupffer cell	Kupffer cell	CL:0000091	Kupffer	4			macrophage	CL:0000235	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
+granulocyte	granulocyte	CL:0000094	Granulocyte	3					myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
+mast cell	mast cell	CL:0000097	Mast	3					myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
+interneuron	interneuron	CL:0000099	Interneuron	3					neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+bipolar neuron	bipolar neuron	CL:0000103	BipolarN	3					neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+cholinergic neuron	cholinergic neuron	CL:0000108	CholinergicN	3					neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+endothelial cell	endothelial cell	CL:0000115	Endothelial	1									cell	CL:0000548
+basket cell	basket cell	CL:0000118	Basket	4			central nervous system neuron	CL:2000029	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+granule cell	granule cell	CL:0000120	Granule	4			central nervous system neuron	CL:2000029	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+Purkinje cell	Purkinje cell	CL:0000121	Purkinje	4			central nervous system neuron	CL:2000029	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+glial cell	glial cell	CL:0000125	Glial	2							neural cell	CL:0002319	cell	CL:0000548
+macroglial cell	macroglial cell	CL:0000126	Macroglial	3					glial cell	CL:0000125	neural cell	CL:0002319	cell	CL:0000548
+astrocyte	astrocyte	CL:0000127	Astrocyte	4			macroglial cell	CL:0000126	glial cell	CL:0000125	neural cell	CL:0002319	cell	CL:0000548
+oligodendrocyte	oligodendrocyte	CL:0000128	Oligodendrocyte	4			macroglial cell	CL:0000126	glial cell	CL:0000125	neural cell	CL:0002319	cell	CL:0000548
+microglial cell	microglial cell	CL:0000129	Microglial	5	central nervous system macrophage	CL:0000878	macrophage	CL:0000235	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
+mesenchymal stem cell	mesenchymal stem cell	CL:0000134	MesenchymalStem	4			multi fate stem cell	CL:0000048	stem cell	CL:0000034	precursor cell	CL:0011115	cell	CL:0000548
+pigment cell	pigment cell	CL:0000147	Pigment	2							epithelial cell	CL:0000066	cell	CL:0000548
+glandular epithelial cell	glandular epithelial cell	CL:0000150	GlandularEpithelial	2							epithelial cell	CL:0000066	cell	CL:0000548
+sebum secreting cell	sebum secreting cell	CL:0000317	SebumSecreting	2							secretory cell	CL:0000151	cell	CL:0000548
+club cell	club cell	CL:0000158	Club	5	bronchial epithelial cell	CL:0002328	respiratory epithelial cell	CL:0002368	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	cell	CL:0000548
+goblet cell	goblet cell	CL:0000160	Goblet	3					glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	cell	CL:0000548
+endocrine cell	endocrine cell	CL:0000163	Endocrine	2							secretory cell	CL:0000151	cell	CL:0000548
+enteroendocrine cell	enteroendocrine cell	CL:0000164	Enteroendocrine	3					glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	cell	CL:0000548
+neuroendocrine cell	neuroendocrine cell	CL:0000165	Neuroendocrine	3					endocrine cell	CL:0000163	secretory cell	CL:0000151	cell	CL:0000548
+type B pancreatic cell	type B pancreatic cell	CL:0000169	BetaPancreatic	5	pancreatic endocrine cell	CL:0008024	enteroendocrine cell	CL:0000164	glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	cell	CL:0000548
+pancreatic A cell	pancreatic A cell	CL:0000171	AlphaPancreatic	5	pancreatic endocrine cell	CL:0008024	enteroendocrine cell	CL:0000164	glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	cell	CL:0000548
+pancreatic D cell	pancreatic D cell	CL:0000173	DeltaPancreatic	5	pancreatic endocrine cell	CL:0008024	enteroendocrine cell	CL:0000164	glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	cell	CL:0000548
+Leydig cell	Leydig cell	CL:0000178	Leydig	2							secretory cell	CL:0000151	cell	CL:0000548
+hepatocyte	hepatocyte	CL:0000182	Hepatocyte	2							epithelial cell	CL:0000066	cell	CL:0000548
+contractile cell	contractile cell	CL:0000183	Contractile	1									cell	CL:0000548
+myofibroblast cell	myofibroblast cell	CL:0000186	Myofibroblast	2							contractile cell	CL:0000183	cell	CL:0000548
+muscle cell	muscle cell	CL:0000187	MuscleCell	2							contractile cell	CL:0000183	cell	CL:0000548
+smooth muscle cell	smooth muscle cell	CL:0000192	SmoothMuscle	3					muscle cell	CL:0000187	contractile cell	CL:0000183	cell	CL:0000548
+photoreceptor cell	photoreceptor cell	CL:0000210	Photoreceptor	4			sensory neuron	CL:0000101	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+serous secreting cell	serous secreting cell	CL:0000313	SerousSecreting	2							secretory cell	CL:0000151	cell	CL:0000548
+myelinating Schwann cell	myelinating Schwann cell	CL:0000218	MyelinSchwann	4			Schwann cell	CL:0002573	glial cell	CL:0000125	neural cell	CL:0002319	cell	CL:0000548
+erythrocyte	erythrocyte	CL:0000232	Erythrocyte	3					erythroid lineage cell	CL:0000764	hematopoietic cell	CL:0000988	cell	CL:0000548
+macrophage	macrophage	CL:0000235	Macrophage	3					myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
+B cell	B cell	CL:0000236	Bcell	3					lymphocyte of B lineage	CL:0000945	hematopoietic cell	CL:0000988	cell	CL:0000548
+tracheal epithelial cell	tracheal epithelial cell	CL:0000307	TrachealEpithelial	4			respiratory epithelial cell	CL:0002368	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	cell	CL:0000548
+keratinocyte	keratinocyte	CL:0000312	Keratinocyte	4			epidermal cell	CL:0000362	ecto-epithelial cell	CL:0002077	epithelial cell	CL:0000066	cell	CL:0000548
+pneumocyte	pneumocyte	CL:0000322	Pneumocyte	3					epithelial cell of lung	CL:0000082	epithelial cell	CL:0000066	cell	CL:0000548
+epidermal cell	epidermal cell	CL:0000362	Epidermal	3					ecto-epithelial cell	CL:0002077	epithelial cell	CL:0000066	cell	CL:0000548
+Langerhans cell	Langerhans cell	CL:0000453	Langerhans	4			myeloid dendritic cell	CL:0000782	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
+CD4-positive helper T cell	CD4-positive helper T cell	CL:0000492	ThCD4Tcell	5	"CD4-positive, alpha-beta T cell"	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+stromal cell	stromal cell	CL:0000499	Stromal	2							connective tissue cell	CL:0002320	cell	CL:0000548
+paneth cell	paneth cell	CL:0000510	Paneth	4			intestinal epithelial cell	CL:0002563	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	cell	CL:0000548
+neuron	neuron	CL:0000540	Neuron	2							neural cell	CL:0002319	cell	CL:0000548
+lymphocyte	lymphocyte	CL:0000542	Lymphocyte	2							hematopoietic cell	CL:0000988	cell	CL:0000548
+T-helper 1 cell	T-helper 1 cell	CL:0000545	Th1CD4Tcell	5	"CD4-positive, alpha-beta T cell"	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+proerythroblast	proerythroblast	CL:0000547	Proerythroblast	3					erythroid lineage cell	CL:0000764	hematopoietic cell	CL:0000988	cell	CL:0000548
+cell	cell	CL:0000548	Cell	0										
+megakaryocyte	megakaryocyte	CL:0000556	Megakaryocyte	2							hematopoietic cell	CL:0000988	cell	CL:0000548
+granulocyte monocyte progenitor cell	granulocyte monocyte progenitor cell	CL:0000557	GranuloMonocytePC	3					hematopoietic precursor cell	CL:0008001	hematopoietic cell	CL:0000988	cell	CL:0000548
+promonocyte	promonocyte	CL:0000559	Promonocyte	3					hematopoietic precursor cell	CL:0008001	hematopoietic cell	CL:0000988	cell	CL:0000548
+amacrine cell	amacrine cell	CL:0000561	Amacrine	2							neural cell	CL:0002319	cell	CL:0000548
+retinal cone cell	retinal cone cell	CL:0000573	RetinalCone	5	photoreceptor cell	CL:0000210	sensory neuron	CL:0000101	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+monocyte	monocyte	CL:0000576	Monocyte	3					myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
+alveolar macrophage	alveolar macrophage	CL:0000583	AlvelolarMacrophage	5	lung macrophage	CL:1001603	macrophage	CL:0000235	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
+enterocyte	enterocyte	CL:0000584	Enterocyte	4			intestinal epithelial cell	CL:0002563	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	cell	CL:0000548
+skeletal muscle fiber	skeletal muscle fiber	CL:0008002	SkeletalMuscle	3					muscle cell	CL:0000187	contractile cell	CL:0000183	cell	CL:0000548
+pyramidal neuron	pyramidal neuron	CL:0000598	Pyramidal	3					neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+retinal rod cell	retinal rod cell	CL:0000604	RetinalRod	5	photoreceptor cell	CL:0000210	sensory neuron	CL:0000101	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+GABAergic neuron	GABAergic neuron	CL:0000617	GABAergicN	3					neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+acinar cell	acinar cell	CL:0000622	Acinar	3					glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	cell	CL:0000548
+natural killer cell	natural killer cell	CL:0000623	NKcell	4			innate lymphoid cell	CL:0001065	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+"CD4-positive, alpha-beta T cell"	"CD4-positive, alpha-beta T cell"	CL:0000624	CD4Tcell	4			T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+"CD8-positive, alpha-beta T cell"	"CD8-positive, alpha-beta T cell"	CL:0000625	CD8Tcell	4			T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+Mueller cell	Mueller cell	CL:0000636	Mueller	5	astrocyte	CL:0000127	macroglial cell	CL:0000126	glial cell	CL:0000125	neural cell	CL:0002319	cell	CL:0000548
+Bergmann glial cell	Bergmann glial cell	CL:0000644	BergmannGlial	5	astrocyte	CL:0000127	macroglial cell	CL:0000126	glial cell	CL:0000125	neural cell	CL:0002319	cell	CL:0000548
+basal cell	basal cell	CL:0000646	Basal	5	epithelial fate stem cell	CL:0000036	somatic stem cell	CL:0000723	stem cell	CL:0000034	precursor cell	CL:0011115	cell	CL:0000548
+mesangial cell	mesangial cell	CL:0000650	Mesangial	3					pericyte	CL:0000669	connective tissue cell	CL:0002320	cell	CL:0000548
+pericyte	pericyte	CL:0000669	Pericyte	2							connective tissue cell	CL:0002320	cell	CL:0000548
+glutamatergic neuron	glutamatergic neuron	CL:0000679	GlutamatergicN	3					neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+muscle precursor cell	muscle precursor cell	CL:0000680	MusclePC	2							precursor cell	CL:0011115	cell	CL:0000548
+radial glial cell	radial glial cell	CL:0000681	RadialGlial	3					glial cell	CL:0000125	neural cell	CL:0002319	cell	CL:0000548
+microfold cell	M cell of gut	CL:0000682	McellGut	3					endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	cell	CL:0000548
+Cajal-Retzius cell	Cajal-Retzius cell	CL:0000695	CajalRetzius	4			central nervous system neuron	CL:2000029	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+PP cell	PP cell	CL:0000696	PPcell	4			enteroendocrine cell	CL:0000164	glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	cell	CL:0000548
+dopaminergic neuron	dopaminergic neuron	CL:0000700	DopaminergicN	3					neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+endothelial tip cell	endothelial tip cell	CL:0000704	TipEndothelial	4			blood vessel endothelial cell	CL:0000071	endothelial cell of vascular tree	CL:0002139	endothelial cell	CL:0000115	cell	CL:0000548
+leptomeningeal cell	leptomeningeal cell	CL:0000708	Leptomeningeal	2							neural cell	CL:0002319	cell	CL:0000548
+somatic stem cell	somatic stem cell	CL:0000723	SomaticStem	3					stem cell	CL:0000034	precursor cell	CL:0011115	cell	CL:0000548
+striated muscle cell	striated muscle cell	CL:0000737	StriatedMuscle	3					muscle cell	CL:0000187	contractile cell	CL:0000183	cell	CL:0000548
+leukocyte	leukocyte	CL:0000738	Leukocyte	2							hematopoietic cell	CL:0000988	cell	CL:0000548
+retinal ganglion cell	retinal ganglion cell	CL:0000740	RetinalGanglion	4			central nervous system neuron	CL:2000029	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+retina horizontal cell	retina horizontal cell	CL:0000745	RetinalHorizontal	4			interneuron	CL:0000099	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+cardiac muscle cell	cardiac muscle cell	CL:0000746	CardiacMuscle	4			striated muscle cell	CL:0000737	muscle cell	CL:0000187	contractile cell	CL:0000183	cell	CL:0000548
+retinal bipolar neuron	retinal bipolar neuron	CL:0000748	RetinalBPNeuron	4			bipolar neuron	CL:0000103	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+OFF-bipolar cell	OFF-bipolar cell	CL:0000750	OFFBipolar	5	retinal bipolar neuron	CL:0000748	bipolar neuron	CL:0000103	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+ON-bipolar cell	ON-bipolar cell	CL:0000749	ONBipolar	5	retinal bipolar neuron	CL:0000748	bipolar neuron	CL:0000103	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+rod bipolar cell	rod bipolar cell	CL:0000751	RodBipolar	5	retinal bipolar neuron	CL:0000748	bipolar neuron	CL:0000103	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+cone retinal bipolar cell	cone retinal bipolar cell	CL:0000752	ConeBipolar	5	retinal bipolar neuron	CL:0000748	bipolar neuron	CL:0000103	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+nucleated thrombocyte	nucleated thrombocyte	CL:0000762	NucleatedThrombocyte	3					myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
+erythroid lineage cell	erythroid lineage cell	CL:0000764	Erythroid	2							hematopoietic cell	CL:0000988	cell	CL:0000548
+erythroblast	erythroblast	CL:0000765	Erythroblast	3					erythroid lineage cell	CL:0000764	hematopoietic cell	CL:0000988	cell	CL:0000548
+myeloid leukocyte	myeloid leukocyte	CL:0000766	Myeloid	2							hematopoietic cell	CL:0000988	cell	CL:0000548
+basophil	basophil	CL:0000767	Basophil	4			granulocyte	CL:0000094	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
+eosinophil	eosinophil	CL:0000771	Eosinophil	4			granulocyte	CL:0000094	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
+neutrophil	neutrophil	CL:0000775	Neutrophil	4			granulocyte	CL:0000094	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
+myeloid dendritic cell	myeloid dendritic cell	CL:0000782	cDC	3					myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
+plasmacytoid dendritic cell	plasmacytoid dendritic cell	CL:0000784	pDC	3					lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+plasma cell	plasma cell	CL:0000786	Plasma	3					lymphocyte of B lineage	CL:0000945	hematopoietic cell	CL:0000988	cell	CL:0000548
+memory B cell	memory B cell	CL:0000787	MemBcell	4			B cell	CL:0000236	lymphocyte of B lineage	CL:0000945	hematopoietic cell	CL:0000988	cell	CL:0000548
+naive B cell	naive B cell	CL:0000788	NaiBcell	4			B cell	CL:0000236	lymphocyte of B lineage	CL:0000945	hematopoietic cell	CL:0000988	cell	CL:0000548
+"CD8-positive, alpha-beta cytotoxic T cell"	"CD8-positive, alpha-beta cytotoxic T cell"	CL:0000794	CytotoxCD8Tcell	5	"CD8-positive, alpha-beta T cell"	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+gamma-delta T cell	gamma-delta T cell	CL:0000798	gdTcell	4			T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+memory T cell	memory T cell	CL:0000813	MemTcell	4			T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+mature NK T cell	mature NK T cell	CL:0000814	NKTcell	4			T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+regulatory T cell	regulatory T cell	CL:0000815	RegTcell	4			T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+immature B cell	immature B cell	CL:0000816	ImmatureBcell	4			B cell	CL:0000236	lymphocyte of B lineage	CL:0000945	hematopoietic cell	CL:0000988	cell	CL:0000548
+precursor B cell	precursor B cell	CL:0000817	BcellPC	4			B cell	CL:0000236	lymphocyte of B lineage	CL:0000945	hematopoietic cell	CL:0000988	cell	CL:0000548
+immature natural killer cell	immature natural killer cell	CL:0000823	ImmatureNK	5	natural killer cell	CL:0000623	innate lymphoid cell	CL:0001065	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+pro-B cell	pro-B cell	CL:0000826	ProBcell	3					lymphoid lineage restricted progenitor cell	CL:0000838	hematopoietic cell	CL:0000988	cell	CL:0000548
+pro-T cell	pro-T cell	CL:0000827	ProTcell	3					lymphoid lineage restricted progenitor cell	CL:0000838	hematopoietic cell	CL:0000988	cell	CL:0000548
+hematopoietic multipotent progenitor cell	hematopoietic multipotent progenitor cell	CL:0000837	HematoMultipotentPC	3					hematopoietic precursor cell	CL:0008001	hematopoietic cell	CL:0000988	cell	CL:0000548
+lymphoid lineage restricted progenitor cell	lymphoid lineage restricted progenitor cell	CL:0000838	LymphoidPC	2							hematopoietic cell	CL:0000988	cell	CL:0000548
+myeloid lineage restricted progenitor cell	myeloid lineage restricted progenitor cell	CL:0000839	MyeloidPC	3					hematopoietic precursor cell	CL:0008001	hematopoietic cell	CL:0000988	cell	CL:0000548
+follicular B cell	follicular B cell	CL:0000843	FollicularBcell	4			B cell	CL:0000236	lymphocyte of B lineage	CL:0000945	hematopoietic cell	CL:0000988	cell	CL:0000548
+germinal center B cell	germinal center B cell	CL:0000844	GermCenterBcell	4			B cell	CL:0000236	lymphocyte of B lineage	CL:0000945	hematopoietic cell	CL:0000988	cell	CL:0000548
+classical monocyte	classical monocyte	CL:0000860	ClassMonocyte	4			monocyte	CL:0000576	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
+non-classical monocyte	non-classical monocyte	CL:0000875	NClassMonocyte	4			monocyte	CL:0000576	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
+central nervous system macrophage	central nervous system macrophage	CL:0000878	CNSMacrophage	4			macrophage	CL:0000235	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
+perivascular macrophage	perivascular macrophage	CL:0000881	PerivascMacrophage	5	central nervous system macrophage	CL:0000878	macrophage	CL:0000235	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
+DN1 thymic pro-T cell	DN1 thymic pro-T cell	CL:0000894	DN1ProTcell	4			pro-T cell	CL:0000827	lymphoid lineage restricted progenitor cell	CL:0000838	hematopoietic cell	CL:0000988	cell	CL:0000548
+"naive thymus-derived CD4-positive, alpha-beta T cell"	"naive thymus-derived CD4-positive, alpha-beta T cell"	CL:0000895	NaiCD4Tcell	5	"CD4-positive, alpha-beta T cell"	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+"activated CD4-positive, alpha-beta T cell"	"activated CD4-positive, alpha-beta T cell"	CL:0000896	ActCD4Tcell	5	"CD4-positive, alpha-beta T cell"	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+"CD4-positive, alpha-beta memory T cell"	"CD4-positive, alpha-beta memory T cell"	CL:0000897	MemCD4Tcell	5	"CD4-positive, alpha-beta T cell"	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+T-helper 17 cell	T-helper 17 cell	CL:0000899	Th17CD4Tcell	5	"CD4-positive, alpha-beta T cell"	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+"naive thymus-derived CD8-positive, alpha-beta T cell"	"naive thymus-derived CD8-positive, alpha-beta T cell"	CL:0000900	NaiCD8Tcell	5	"CD8-positive, alpha-beta T cell"	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+"central memory CD4-positive, alpha-beta T cell"	"central memory CD4-positive, alpha-beta T cell"	CL:0000904	CMCD4Tcell	5	"CD4-positive, alpha-beta T cell"	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+"effector memory CD4-positive, alpha-beta T cell"	"effector memory CD4-positive, alpha-beta T cell"	CL:0000905	EMCD4Tcell	5	"CD4-positive, alpha-beta T cell"	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+"activated CD8-positive, alpha-beta T cell"	"activated CD8-positive, alpha-beta T cell"	CL:0000906	ActCD8Tcell	5	"CD8-positive, alpha-beta T cell"	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+"central memory CD8-positive, alpha-beta T cell"	"central memory CD8-positive, alpha-beta T cell"	CL:0000907	CMCD8Tcell	5	"CD8-positive, alpha-beta T cell"	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+"CD8-positive, alpha-beta cytokine secreting effector T cell"	"CD8-positive, alpha-beta cytokine secreting effector T cell"	CL:0000908	CytokineCD8Tcell	5	"CD8-positive, alpha-beta T cell"	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+effector T cell	effector T cell	CL:0000911	EffTcell	4			T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+"effector memory CD8-positive, alpha-beta T cell"	"effector memory CD8-positive, alpha-beta T cell"	CL:0000913	EMCD8Tcell	5	"CD8-positive, alpha-beta T cell"	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+immature NK T cell	immature NK T cell	CL:0000914	ImmatureNKTcell	4			T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+"CD4-positive, alpha-beta cytotoxic T cell"	"CD4-positive, alpha-beta cytotoxic T cell"	CL:0000934	CytotoxCD4Tcell	5	"CD4-positive, alpha-beta T cell"	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+pre-natural killer cell	pre-natural killer cell	CL:0000937	PreNKcell	5	natural killer cell	CL:0000623	innate lymphoid cell	CL:0001065	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+CD56-bright cytokine secreting natural killer cell	CD56-bright cytokine secreting natural killer cell	CL:0000938	CD56brightNK	5	natural killer cell	CL:0000623	innate lymphoid cell	CL:0001065	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+cytotoxic CD56-dim natural killer cell	cytotoxic CD56-dim natural killer cell	CL:0000939	CD56dimNK	5	natural killer cell	CL:0000623	innate lymphoid cell	CL:0001065	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+mucosal invariant T cell	mucosal invariant T cell	CL:0000940	MAIT	4			T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+lymphocyte of B lineage	lymphocyte of B lineage	CL:0000945	Blymphocyte	2							hematopoietic cell	CL:0000988	cell	CL:0000548
+hematopoietic cell	hematopoietic cell	CL:0000988	Hematopoietic	1									cell	CL:0000548
+cerebellar granule cell	cerebellar granule cell	CL:0001031	CerebellarGranule	5	granule cell	CL:0000120	central nervous system neuron	CL:2000029	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+bone cell	bone cell	CL:0001035	BoneCell	1									cell	CL:0000548
+"effector CD4-positive, alpha-beta T cell"	"effector CD4-positive, alpha-beta T cell"	CL:0001044	EffCD4Tcell	5	"CD4-positive, alpha-beta T cell"	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
 neoplastic cell	neoplastic cell	CL:0001063	Neoplastic	0										
 malignant cell	malignant cell	CL:0001064	Malignant	1									neoplastic cell	CL:0001063
-innate lymphoid cell	innate lymphoid cell	CL:0001065	InnateLymphoid	3					lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-pre-conventional dendritic cell	pre-conventional dendritic cell	CL:0002010	PrecDC	3					hematopoietic precursor cell	CL:0008001	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-short term hematopoietic stem cell	short term hematopoietic stem cell	CL:0002033	STHematoStem	4			hematopoietic stem cell	CL:0000037	hematopoietic precursor cell	CL:0008001	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-long term hematopoietic stem cell	long term hematopoietic stem cell	CL:0002034	LTHematoStem	4			hematopoietic stem cell	CL:0000037	hematopoietic precursor cell	CL:0008001	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-Slamf1-negative multipotent progenitor cell	Slamf1-negative multipotent progenitor cell	CL:0002035	MultipotentPC_SLAMFneg	4			hematopoietic multipotent progenitor cell	CL:0000837 	hematopoietic precursor cell	CL:0008001	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-Slamf1-positive multipotent progenitor cell	Slamf1-positive multipotent progenitor cell	CL:0002036	MultipotentPC_SLAMF	4			hematopoietic multipotent progenitor cell	CL:0000837 	hematopoietic precursor cell	CL:0008001	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-Fraction A pre-pro B cell	Fraction A pre-pro B cell	CL:0002045	FrAPreProBcell	4			pro-B cell	CL:0000826	lymphoid lineage restricted progenitor cell	CL:0000838 	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-early pro-B cell	early pro-B cell	CL:0002046	EarlyProBcell	4			pro-B cell	CL:0000826	lymphoid lineage restricted progenitor cell	CL:0000838 	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-late pro-B cell	late pro-B cell	CL:0002048	LateProBcell	4			pro-B cell	CL:0000826	lymphoid lineage restricted progenitor cell	CL:0000838 	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-type I pneumocyte	type I pneumocyte	CL:0002062	T1Pneumocyte	4			pneumocyte	CL:0000322	epithelial cell of lung	CL:0000082	epithelial cell	CL:0000066	animal cell	CL:0000548
-type II pneumocyte	type II pneumocyte	CL:0002063	T2Pneumocyte	4			pneumocyte	CL:0000322	epithelial cell of lung	CL:0000082	epithelial cell	CL:0000066	animal cell	CL:0000548
-pancreatic acinar cell	pancreatic acinar cell	CL:0002064	PancreaticAcinar	4			acinar cell	CL:0000622	glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	animal cell	CL:0000548
-enterocyte of epithelium of large intestine	enterocyte of epithelium of large intestine	CL:0002071	EnterocyteLargeIntest	5	enterocyte	CL:0000584	intestinal epithelial cell	CL:0002563	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	animal cell	CL:0000548
-endo-epithelial cell	endo-epithelial cell	CL:0002076	EndoEpithelial	2							epithelial cell	CL:0000066	animal cell	CL:0000548
-ecto-epithelial cell	ecto-epithelial cell	CL:0002077	EctoEpithelial	2							epithelial cell	CL:0000066	animal cell	CL:0000548
-pancreatic ductal cell	pancreatic ductal cell	CL:0002079	PancreaticDuctal	3					duct epithelial cell	CL:0000068	epithelial cell	CL:0000066	animal cell	CL:0000548
-tanycyte	tanycyte	CL:0002085	Tanycyte	5	astrocyte	CL:0000127	macrogial cell	CL:0000126	glial cell	CL:0000125	neural cell	CL:0002319	animal cell	CL:0000548
-bone marrow cell	bone marrow cell	CL:0002092	BoneMarrowCell	2							bone cell	CL:0001035	animal cell	CL:0000548
-endothelial cell of vascular tree	endothelial cell of vascular tree	CL:0002139	EndothelialVascular	2							endothelial cell	CL:0000115	animal cell	CL:0000548
-ciliated columnar cell of tracheobronchial tree	ciliated columnar cell of tracheobronchial tree	CL:0002145	CCTracheobronchial	4			respiratory epithelial cell	CL:0002368	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	animal cell	CL:0000548
-basal cell of epidermis	basal cell of epidermis	CL:0002187	BasalEpidermis	5	keratinocyte	CL:0000312	epidermal cell	CL:0000362	ecto-epithelial cell	CL:0002077	epithelial cell	CL:0000066	animal cell	CL:0000548
-granulocytopoietic cell	granulocytopoietic cell	CL:0002191	Granulocytopoietic	4			myeloid lineage restricted progenitor cell	CL:0000839	hematopoietic precursor cell	CL:0008001	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-brush cell of epithelium proper of large intestine	brush cell of epithelium proper of large intestine	CL:0002203	LargeIntestineBrush	4			brush cell	CL:0002204	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	animal cell	CL:0000548
-brush cell	brush cell	CL:0002204	Brush	3					endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	animal cell	CL:0000548
-epithelial cell of large intestine	epithelial cell of large intestine	CL:0002253	LargeIntestineEpith	4			intestinal epithelial cell	CL:0002563	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	animal cell	CL:0000548
-neuroepithelial stem cell	neuroepithelial stem cell	CL:0002259	NeuroepithelialStem	3			somatic stem cell	CL:0000723	stem cell	CL:0000034	precursor cell	CL:0011115	animal cell	CL:0000548
-endothelial cell of sinusoid	endothelial cell of sinusoid	CL:0002262	EndothelialSinusoid	2							endothelial cell	CL:0000115	animal cell	CL:0000548
-pancreatic PP cell	pancreatic PP cell	CL:0002275	PancreaticPP	5	PP cell	CL:0000696	enteroendocrine cell	CL:0000164	glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	animal cell	CL:0000548
-epithelial cell of distal tubule	epithelial cell of distal tubule	CL:0002305	TubuleEpithelial	4			kidney tubule cell	CL:1000507	kidney epithelial cell	CL:0002518	epithelial cell	CL:0000066	animal cell	CL:0000548
-epithelial cell of proximal tubule	epithelial cell of proximal tubule	CL:0002306	ProximalTubule	5	kidney tubule cell	CL:1000507	epithelial cell of nephron	CL:1000449	kidney epithelial cell	CL:0002518	epithelial cell	CL:0000066	animal cell	CL:0000548
-epithelial cell of proximal tubule	epithelial cell of proximal tubule	CL:0002306	ProximalTubule	5	kidney tubule cell	CL:1000507	epithelial cell of nephron	CL:1000449	kidney epithelial cell	CL:0002518	epithelial cell	CL:0000066	animal cell	CL:0000548
-neural cell	neural cell	CL:0002319	Neural	1									animal cell	CL:0000548
-connective tissue cell	connective tissue cell	CL:0002320	ConnectiveTissue	1									animal cell	CL:0000548
-embryonic stem cell	embryonic stem cell	CL:0002322	EmbryonicStem	3					stem cell	CL:0000034	precursor cell	CL:0011115	animal cell	CL:0000548
-luminal epithelial cell of mammary gland	luminal epithelial cell of mammary gland	CL:0002326	MammaryLumEpith	4			branched duct epithelial cell	CL:0000069	duct epithelial cell	CL:0000068	epithelial cell	CL:0000066	animal cell	CL:0000548
-bronchial epithelial cell	bronchial epithelial cell	CL:0002328	BronchialEpithelial	4			respiratory epithelial cell	CL:0002368	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	animal cell	CL:0000548
-keratinocyte stem cell	keratinocyte stem cell	CL:0002337	KeratinocyteStem	5	keratinocyte	CL:0000312	epidermal cell	CL:0000362	ecto-epithelial cell	CL:0002077	epithelial cell	CL:0000066	animal cell	CL:0000548
-endocardial cell	endocardial cell	CL:0002350	Endocardial	3					cardiac endothelial cell	CL:0002350	endothelial cell	CL:0000115	animal cell	CL:0000548
-respiratory epithelial cell	respiratory epithelial cell	CL:0002368	RespiratoryEpithelial	3					endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	animal cell	CL:0000548
-CD141-positive myeloid dendritic cell	CD141-positive myeloid dendritic cell	CL:0002394	cDC1	5			myeloid dendritic cell	CL:0002394	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-CD1c-positive myeloid dendritic cell	CD1c-positive myeloid dendritic cell	CL:0002399	cDC2	5			myeloid dendritic cell	CL:0002394	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-pancreatic stellate cell	pancreatic stellate cell	CL:0002410	PancStellate	3					fibroblast	CL:0000057	connective tissue cell	CL:0002320	animal cell	CL:0000548
-immature T cell	immature T cell	CL:0002420	ImmatureTcell	4			T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-oligodendrocyte precursor cell	oligodendrocyte precursor cell	CL:0002453	OligodendrocytePC	5	oligodendrocyte	CL:0000128	macrogial cell	CL:0000126	glial cell	CL:0000125	neural cell	CL:0002319	animal cell	CL:0000548
-kidney epithelial cell	kidney epithelial cell	CL:0002518	KidneyEpithelial	2							epithelial cell	CL:0000066	animal cell	CL:0000548
-fibroblast of lung	fibroblast of lung	CL:0002553	LungFibroblast	3					fibroblast	CL:0000057	connective tissue cell	CL:0002320	animal cell	CL:0000548
-intestinal epithelial cell	intestinal epithelial cell	CL:0002563	IntestinalEpithelial	3					endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	animal cell	CL:0000548
-mesenchymal stem cell of adipose	mesenchymal stem cell of adipose	CL:0002570	AdiposeMSC	5	mesenchymal stem cell	CL:0000134	multi fate stem cell	CL:0000048	stem cell	CL:0000034	precursor cell	CL:0011115	animal cell	CL:0000548
-Schwann cell	Schwann cell	CL:0002573	Schwann	3					glial cell	CL:0000125	neural cell	CL:0002319	animal cell	CL:0000548
-central nervous system pericyte	central nervous system pericyte	CL:0002575	CNSPericyte	3					pericyte	CL:0000669	connective tissue cell	CL:0002320	animal cell	CL:0000548
-renal cortical epithelial cell	renal cortical epithelial cell	CL:0002584	RenalCorticalEpith	3					kidney epithelial cell	CL:0002518	epithelial cell	CL:0000066	animal cell	CL:0000548
-retinal blood vessel endothelial cell	retinal blood vessel endothelial cell	CL:0002585	RetinalVesselEndo	4			blood vessel endothelial cell	CL:0000071	endothelial cell of vascular tree	CL:0002139	endothelial cell	CL:0000115	animal cell	CL:0000548
-retinal pigment epithelial cell	retinal pigment epithelial cell	CL:0002586	RetPigmentEpith	3					pigment cell	CL:0000147	epithelial cell	CL:0000066	animal cell	CL:0000548
-endothelial cell of high endothelial venule	endothelial cell of high endothelial venule	CL:0002652	HEVEndothelial	3					endothelial cell of vascular tree	CL:0002139	endothelial cell	CL:0000115	animal cell	CL:0000548
-endothelial stalk cell	endothelial stalk cell	CL:0002671	StalkEndothelial	4			blood vessel endothelial cell	CL:0000071	endothelial cell of vascular tree	CL:0002139	endothelial cell	CL:0000115	animal cell	CL:0000548
-ionocyte	ionocyte	CL:0005006	Ionocyte	2							epithelial cell	CL:0000066	animal cell	CL:0000548
-pancreatic epsilon cell	pancreatic epsilon cell	CL:0005019	EpsilonPancreatic	5	pancreatic endocrine cell	CL:0008024	enteroendocrine cell	CL:0000164	glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	animal cell	CL:0000548
-hematopoietic precursor cell	hematopoietic precursor cell	CL:0008001	HematopoieticPC	2							hematopoietic cell	CL:0000988	animal cell	CL:0000548
-skeletal muscle satellite stem cell	skeletal muscle satellite stem cell	CL:0008011	MuscleSatelliteStem	4			skeletal muscle satellite cell	CL:0000594	muscle precursor cell	CL:0000680	precursor cell	CL:0011115	animal cell	CL:0000548
-mesenchymal cell	mesenchymal cell	CL:0008019	Mesenchymal	1									animal cell	CL:0000548
-pancreatic endocrine cell	pancreatic endocrine cell	CL:0008024	PancreaticEndocrine	4			enteroendocrine cell	CL:0000164	glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	animal cell	CL:0000548
-inhibitory neuron	inhibitory neuron	CL:0008029	InhibitoryN	3					neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-excitatory neuron	excitatory neuron	CL:0008030	ExcitatoryN	3					neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-stromal cell of bone marrow	stromal cell of bone marrow	CL:0010001	StromalBoneMarrow	3					bone marrow cell	CL:0002092	bone cell	CL:0001035	animal cell	CL:0000548
-camera-type eye photoreceptor cell	camera-type eye photoreceptor cell	CL:0010009	CameraEyePhotorec	5	photoreceptor cell	CL:0000210	sensory neuron	CL:0000128	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-neural progenitor cell	neural progenitor cell	CL:0011020	NeuralPC	2							precursor cell	CL:0011115	animal cell	CL:0000548
-histaminergic neuron	histaminergic neuron	CL:0011110	HistaminergicN	3					neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-precursor cell	precursor cell	CL:0011115	Precursor	1									animal cell	CL:0000548
-large intestine goblet cell	large intestine goblet cell	CL:1000320	LargeIntestGoblet	4			goblet cell	CL:0000160	glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	animal cell	CL:0000548
-basal cell of epithelium of trachea	basal cell of epithelium of trachea	CL:1000348	BasalTrachealEpith	5	tracheal epithelial cell	CL:0000307	respiratory epithelial cell	CL:0002368	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	animal cell	CL:0000548
-endothelial cell of hepatic sinusoid	endothelial cell of hepatic sinusoid	CL:1000398	LiverSinusoidEndo	3					endothelial cell of sinusoid	CL:0002262	endothelial cell	CL:0000115	animal cell	CL:0000548
-stem cell of epidermis	stem cell of epidermis	CL:1000428	EpidermisStem	4			somatic stem cell	CL:0000723	stem cell	CL:0000034	precursor cell	CL:0011115	animal cell	CL:0000548
-epithelial cell of nephron	epithelial cell of nephron	CL:1000449	NephronEpithelial	3					kidney epithelial cell	CL:0002518	epithelial cell	CL:0000066	animal cell	CL:0000548
-parietal epithelial cell	parietal epithelial cell	CL:1000452	ParietalEpithelial	5	glomerular cell	CL:1000746	renal cortical epithelial cell	CL:0002584	kidney epithelial cell	CL:0002518	epithelial cell	CL:0000066	animal cell	CL:0000548
-kidney collecting duct epithelial cell	kidney collecting duct epithelial cell	CL:1000454	KidneyDuctEpith	4			kidney collecting duct cell	CL:1001225	duct epithelial cell	CL:0000068	epithelial cell	CL:0000066	animal cell	CL:0000548
-cholangiocyte	cholangiocyte	CL:1000488	Cholangiocyte	3					duct epithelial cell	CL:0000068	epithelial cell	CL:0000066	animal cell	CL:0000548
-kidney cell	kidney cell	CL:1000497	KidneyCell	1									animal cell	CL:0000548
-kidney tubule cell	kidney tubule cell	CL:1000507	KidneyTubule	3					kidney epithelial cell	CL:0002518	epithelial cell	CL:0000066	animal cell	CL:0000548
-lower urinary tract cell	lower urinary tract cell	CL:1000600	LowUrinaryTract	1									animal cell	CL:0000548
-glomerular cell	glomerular cell	CL:1000746	Glomerular	4			renal cortical epithelial cell	CL:0002584	kidney epithelial cell	CL:0002518	epithelial cell	CL:0000066	animal cell	CL:0000548
-kidney proximal straight tubule epithelial cell	kidney proximal straight tubule epithelial cell	CL:1000839	ProxStraightTubule	5	epithelial cell of proximal tubule	CL:0002306	kidney tubule cell	CL:1000507	kidney epithelial cell	CL:0002518	epithelial cell	CL:0000066	animal cell	CL:0000548
-kidney distal convoluted tubule epithelial cell	kidney distal convoluted tubule epithelial cell	CL:1000849	DistalConvTubule	5	epithelial cell of distal tubule	CL:0002305	kidney tubule cell	CL:1000507	kidney epithelial cell	CL:0002518	epithelial cell	CL:0000066	animal cell	CL:0000548
-kidney capillary endothelial cell	kidney capillary endothelial cell	CL:1000892	KidneyCapillaryEndo	4			blood vessel endothelial cell	CL:0000071	endothelial cell of vascular tree	CL:0002139	endothelial cell	CL:0000115	animal cell	CL:0000548
-kidney loop of Henle epithelial cell	kidney loop of Henle epithelial cell	CL:1000909	HenleTubule	4			kidney tubule cell	CL:1000507	kidney epithelial cell	CL:0002518	epithelial cell	CL:0000066	animal cell	CL:0000548
-kidney collecting duct cell	kidney collecting duct cell	CL:1001225	KidneyDuct	3					duct epithelial cell	CL:0000068	epithelial cell	CL:0000066	animal cell	CL:0000548
-bladder cell	bladder cell	CL:1001319	BladderCell	2							lower urinary tract cell	CL:1000600	animal cell	CL:0000548
-bladder urothelial cell	bladder urothelial cell	CL:1001428	BladderUrothelial	3					bladder cell	CL:1001319	lower urinary tract cell	CL:1000600	animal cell	CL:0000548
-lung endothelial cell	lung endothelial cell	CL:1001567	LungEndothelial	4			blood vessel endothelial cell	CL:0000071	endothelial cell of vascular tree	CL:0002139	endothelial cell	CL:0000115	animal cell	CL:0000548
-mammary gland glandular cell	mammary gland glandular cell	CL:1001586	MammaryGlandular	3					glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	animal cell	CL:0000548
-lung macrophage	lung macrophage	CL:1001603	LungMacrophage	4			macrophage	CL:0000235	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-bone marrow hematopoietic cell	bone marrow hematopoietic cell	CL:1001610	BoneMarrowHemato	2							hematopoietic cell	CL:0000988	animal cell	CL:0000548
-microvascular endothelial cell	microvascular endothelial cell	CL:2000008	MicroVascEndo	5	microvascular endothelial cell	CL:2000008	blood vessel endothelial cell	CL:0000071	endothelial cell of vascular tree	CL:0002139	endothelial cell	CL:0000115	animal cell	CL:0000548
-cerebellum basket cell	cerebellum basket cell	CL:2000027	CerebellumBasket	5	basket cell	CL:0000118	central nervous system neuron	CL:2000029	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-central nervous system neuron	central nervous system neuron	CL:2000029	CNSNeuron	3					neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-brain pericyte	brain pericyte	CL:2000043	BrainPericyte	4			central nervous system pericyte	CL:0002575	pericyte	CL:0000669	connective tissue cell	CL:0002320	animal cell	CL:0000548
-inflammatory monocyte		DB:0000001	InflamMonocyte	4			monocyte	CL:0000576	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-exhausted-like CD4-positive, alpha-beta T cell		DB:0000002	ExhCD4Tcell	5	CD4-positive, alpha-beta T cell	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-proliferating CD8-positive, alpha-beta T cell		DB:0000003	ProlifCD8Tcell	5	CD8-positive, alpha-beta T cell	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-CCR7-positive myeloid dendritic cell		DB:0000004	cDC_CCR7	4			myeloid dendritic cell	CL:0000782	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-exhausted-like CD8-positive, alpha-beta T cell		DB:0000005	ExhCD8Tcell	5	CD8-positive, alpha-beta T cell	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
+innate lymphoid cell	innate lymphoid cell	CL:0001065	InnateLymphoid	3					lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+pre-conventional dendritic cell	pre-conventional dendritic cell	CL:0002010	PrecDC	3					hematopoietic precursor cell	CL:0008001	hematopoietic cell	CL:0000988	cell	CL:0000548
+Sertoli cell	Sertoli cell	CL:0000216	Sertoli	2							epithelial cell	CL:0000066	cell	CL:0000548
+long term hematopoietic stem cell	long term hematopoietic stem cell	CL:0002034	LTHematoStem	4			hematopoietic stem cell	CL:0000037	hematopoietic precursor cell	CL:0008001	hematopoietic cell	CL:0000988	cell	CL:0000548
+skeletal muscle satellite stem cell	skeletal muscle satellite stem cell	CL:0008011	MuscleSatelliteStem	4			skeletal muscle satellite cell	CL:0000594	muscle precursor cell	CL:0000680	precursor cell	CL:0011115	cell	CL:0000548
+Slamf1-negative multipotent progenitor cell	Slamf1-negative multipotent progenitor cell	CL:0002035	MultipotentPC_SLAMFneg	4			hematopoietic multipotent progenitor cell	CL:0000837	hematopoietic precursor cell	CL:0008001	hematopoietic cell	CL:0000988	cell	CL:0000548
+Fraction A pre-pro B cell	Fraction A pre-pro B cell	CL:0002045	FrAPreProBcell	4			pro-B cell	CL:0000826	lymphoid lineage restricted progenitor cell	CL:0000838	hematopoietic cell	CL:0000988	cell	CL:0000548
+early pro-B cell	early pro-B cell	CL:0002046	EarlyProBcell	4			pro-B cell	CL:0000826	lymphoid lineage restricted progenitor cell	CL:0000838	hematopoietic cell	CL:0000988	cell	CL:0000548
+late pro-B cell	late pro-B cell	CL:0002048	LateProBcell	4			pro-B cell	CL:0000826	lymphoid lineage restricted progenitor cell	CL:0000838	hematopoietic cell	CL:0000988	cell	CL:0000548
+type I pneumocyte	type I pneumocyte	CL:0002062	T1Pneumocyte	4			pneumocyte	CL:0000322	epithelial cell of lung	CL:0000082	epithelial cell	CL:0000066	cell	CL:0000548
+type II pneumocyte	type II pneumocyte	CL:0002063	T2Pneumocyte	4			pneumocyte	CL:0000322	epithelial cell of lung	CL:0000082	epithelial cell	CL:0000066	cell	CL:0000548
+pancreatic acinar cell	pancreatic acinar cell	CL:0002064	PancreaticAcinar	4			acinar cell	CL:0000622	glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	cell	CL:0000548
+enterocyte of epithelium of large intestine	enterocyte of epithelium of large intestine	CL:0002071	EnterocyteLargeIntest	5	enterocyte	CL:0000584	intestinal epithelial cell	CL:0002563	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	cell	CL:0000548
+endo-epithelial cell	endo-epithelial cell	CL:0002076	EndoEpithelial	2							epithelial cell	CL:0000066	cell	CL:0000548
+ecto-epithelial cell	ecto-epithelial cell	CL:0002077	EctoEpithelial	2							epithelial cell	CL:0000066	cell	CL:0000548
+pancreatic ductal cell	pancreatic ductal cell	CL:0002079	PancreaticDuctal	3					duct epithelial cell	CL:0000068	epithelial cell	CL:0000066	cell	CL:0000548
+tanycyte	tanycyte	CL:0002085	Tanycyte	5	astrocyte	CL:0000127	macroglial cell	CL:0000126	glial cell	CL:0000125	neural cell	CL:0002319	cell	CL:0000548
+bone marrow cell	bone marrow cell	CL:0002092	BoneMarrowCell	2							bone cell	CL:0001035	cell	CL:0000548
+endothelial cell of vascular tree	endothelial cell of vascular tree	CL:0002139	EndothelialVascular	2							endothelial cell	CL:0000115	cell	CL:0000548
+ciliated columnar cell of tracheobronchial tree	ciliated columnar cell of tracheobronchial tree	CL:0002145	CCTracheobronchial	4			respiratory epithelial cell	CL:0002368	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	cell	CL:0000548
+basal cell of epidermis	basal cell of epidermis	CL:0002187	BasalEpidermis	5	keratinocyte	CL:0000312	epidermal cell	CL:0000362	ecto-epithelial cell	CL:0002077	epithelial cell	CL:0000066	cell	CL:0000548
+granulocytopoietic cell	granulocytopoietic cell	CL:0002191	Granulocytopoetic	4			myeloid lineage restricted progenitor cell	CL:0000839	hematopoietic precursor cell	CL:0008001	hematopoietic cell	CL:0000988	cell	CL:0000548
+brush cell of epithelium proper of large intestine	brush cell of epithelium proper of large intestine	CL:0002203	LargeIntestineBrush	4			brush cell	CL:0002204	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	cell	CL:0000548
+brush cell	brush cell	CL:0002204	Brush	3					endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	cell	CL:0000548
+epithelial cell of large intestine	epithelial cell of large intestine	CL:0002253	LargeIntestineEpith	4			intestinal epithelial cell	CL:0002563	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	cell	CL:0000548
+neuroepithelial stem cell	neuroepithelial stem cell	CL:0002259	NeuroepithelialStem	4			somatic stem cell	CL:0000723	stem cell	CL:0000034	precursor cell	CL:0011115	cell	CL:0000548
+endothelial cell of sinusoid	endothelial cell of sinusoid	CL:0002262	EndothelialSinusoid	2							endothelial cell	CL:0000115	cell	CL:0000548
+pancreatic PP cell	pancreatic PP cell	CL:0002275	PancreaticPP	5	PP cell	CL:0000696	enteroendocrine cell	CL:0000164	glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	cell	CL:0000548
+epithelial cell of distal tubule	epithelial cell of distal tubule	CL:0002305	TubuleEpithelial	3					epithelial cell of nephron	CL:1000449	epithelial cell	CL:0000066	cell	CL:0000548
+epithelial cell of proximal tubule	epithelial cell of proximal tubule	CL:0002306	ProximalTubule	3					epithelial cell of nephron	CL:1000449	epithelial cell	CL:0000066	cell	CL:0000548
+neural cell	neural cell	CL:0002319	Neural	1									cell	CL:0000548
+connective tissue cell	connective tissue cell	CL:0002320	ConnectiveTissue	1									cell	CL:0000548
+embryonic stem cell	embryonic stem cell	CL:0002322	EmbryonicStem	3					stem cell	CL:0000034	precursor cell	CL:0011115	cell	CL:0000548
+luminal epithelial cell of mammary gland	luminal epithelial cell of mammary gland	CL:0002326	MammaryLumEpith	4			branched duct epithelial cell	CL:0000069	duct epithelial cell	CL:0000068	epithelial cell	CL:0000066	cell	CL:0000548
+bronchial epithelial cell	bronchial epithelial cell	CL:0002328	BronchialEpithelial	4			respiratory epithelial cell	CL:0002368	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	cell	CL:0000548
+keratinocyte stem cell	keratinocyte stem cell	CL:0002337	KeratinocyteStem	5	keratinocyte	CL:0000312	epidermal cell	CL:0000362	ecto-epithelial cell	CL:0002077	epithelial cell	CL:0000066	cell	CL:0000548
+endocardial cell	endocardial cell	CL:0002350	Endocardial	3					cardiac endothelial cell	CL:0010008	endothelial cell	CL:0000115	cell	CL:0000548
+respiratory epithelial cell	respiratory epithelial cell	CL:0002368	RespiratoryEpithelial	3					endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	cell	CL:0000548
+CD141-positive myeloid dendritic cell	CD141-positive myeloid dendritic cell	CL:0002394	cDC1	4			myeloid dendritic cell	CL:0002394	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
+CD1c-positive myeloid dendritic cell	CD1c-positive myeloid dendritic cell	CL:0002399	cDC2	4			myeloid dendritic cell	CL:0002394	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
+pancreatic stellate cell	pancreatic stellate cell	CL:0002410	PancStellate	3					fibroblast	CL:0000057	connective tissue cell	CL:0002320	cell	CL:0000548
+immature T cell	immature T cell	CL:0002420	ImmatureTcell	4			T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+oligodendrocyte precursor cell	oligodendrocyte precursor cell	CL:0002453	OligodendrocytePC	5	oligodendrocyte	CL:0000128	macroglial cell	CL:0000126	glial cell	CL:0000125	neural cell	CL:0002319	cell	CL:0000548
+fibroblast of lung	fibroblast of lung	CL:0002553	LungFibroblast	3					fibroblast	CL:0000057	connective tissue cell	CL:0002320	cell	CL:0000548
+intestinal epithelial cell	intestinal epithelial cell	CL:0002563	IntestinalEpithelial	3					endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	cell	CL:0000548
+mesenchymal stem cell of adipose	mesenchymal stem cell of adipose	CL:0002570	AdiposeMSC	5	mesenchymal stem cell	CL:0000134	multi fate stem cell	CL:0000048	stem cell	CL:0000034	precursor cell	CL:0011115	cell	CL:0000548
+Schwann cell	Schwann cell	CL:0002573	Schwann	3					glial cell	CL:0000125	neural cell	CL:0002319	cell	CL:0000548
+central nervous system pericyte	central nervous system pericyte	CL:0002575	CNSPericyte	3					pericyte	CL:0000669	connective tissue cell	CL:0002320	cell	CL:0000548
+retinal blood vessel endothelial cell	retinal blood vessel endothelial cell	CL:0002585	RetinalVesselEndo	4			blood vessel endothelial cell	CL:0000071	endothelial cell of vascular tree	CL:0002139	endothelial cell	CL:0000115	cell	CL:0000548
+retinal pigment epithelial cell	retinal pigment epithelial cell	CL:0002586	RetPigmentEpith	3					pigment cell	CL:0000147	epithelial cell	CL:0000066	cell	CL:0000548
+endothelial cell of high endothelial venule	endothelial cell of high endothelial venule	CL:0002652	HEVEndothelial	3					endothelial cell of vascular tree	CL:0002139	endothelial cell	CL:0000115	cell	CL:0000548
+endothelial stalk cell	endothelial stalk cell	CL:0002671	StalkEndothelial	4			blood vessel endothelial cell	CL:0000071	endothelial cell of vascular tree	CL:0002139	endothelial cell	CL:0000115	cell	CL:0000548
+ionocyte	ionocyte	CL:0005006	Ionocyte	2							epithelial cell	CL:0000066	cell	CL:0000548
+pancreatic epsilon cell	pancreatic epsilon cell	CL:0005019	EpsilonPancreatic	5	pancreatic endocrine cell	CL:0008024	enteroendocrine cell	CL:0000164	glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	cell	CL:0000548
+hematopoietic precursor cell	hematopoietic precursor cell	CL:0008001	HematopoeticPC	2							hematopoietic cell	CL:0000988	cell	CL:0000548
+skeletal muscle satellite cell	skeletal muscle satellite cell	CL:0000594	MuscleSatellite	3					muscle precursor cell	CL:0000680	precursor cell	CL:0011115	cell	CL:0000548
+mesenchymal cell	mesenchymal cell	CL:0008019	Mesenchymal	1									cell	CL:0000548
+pancreatic endocrine cell	pancreatic endocrine cell	CL:0008024	PancreaticEndocrine	4			enteroendocrine cell	CL:0000164	glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	cell	CL:0000548
+inhibitory neuron	inhibitory neuron	CL:0008029	InhibitoryN	3					neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+excitatory neuron	excitatory neuron	CL:0008030	ExcitatoryN	3					neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+stromal cell of bone marrow	stromal cell of bone marrow	CL:0010001	StromalBoneMarrow	3					bone marrow cell	CL:0002092	bone cell	CL:0001035	cell	CL:0000548
+camera-type eye photoreceptor cell	camera-type eye photoreceptor cell	CL:0010009	CameraEyePhotorec	5	photoreceptor cell	CL:0000210	sensory neuron	CL:0000101	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+neural progenitor cell	neural progenitor cell	CL:0011020	NeuralPC	2							precursor cell	CL:0011115	cell	CL:0000548
+histaminergic neuron	histaminergic neuron	CL:0011110	HistaminergicN	3					neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+precursor cell	precursor cell	CL:0011115	Precursor	1									cell	CL:0000548
+large intestine goblet cell	large intestine goblet cell	CL:1000320	LargeIntestGoblet	4			goblet cell	CL:0000160	glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	cell	CL:0000548
+basal cell of epithelium of trachea	basal cell of epithelium of trachea	CL:1000348	BasalTrachealEpith	5	tracheal epithelial cell	CL:0000307	respiratory epithelial cell	CL:0002368	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	cell	CL:0000548
+endothelial cell of hepatic sinusoid	endothelial cell of hepatic sinusoid	CL:1000398	LiverSinusoidEndo	3					endothelial cell of sinusoid	CL:0002262	endothelial cell	CL:0000115	cell	CL:0000548
+stem cell of epidermis	stem cell of epidermis	CL:1000428	EpidermisStem	4			somatic stem cell	CL:0000723	stem cell	CL:0000034	precursor cell	CL:0011115	cell	CL:0000548
+epithelial cell of nephron	epithelial cell of nephron	CL:1000449	NephronEpithelial	2							epithelial cell	CL:0000066	cell	CL:0000548
+parietal epithelial cell	parietal epithelial cell	CL:1000452	ParietalEpithelial	4			kidney glomerular epithelial cell	CL:1000510	epithelial cell of nephron	CL:1000449	epithelial cell	CL:0000066	cell	CL:0000548
+cholangiocyte	cholangiocyte	CL:1000488	Cholangiocyte	3					duct epithelial cell	CL:0000068	epithelial cell	CL:0000066	cell	CL:0000548
+lower urinary tract cell	lower urinary tract cell	CL:1000600	LowUrinaryTract	1									cell	CL:0000548
+kidney proximal straight tubule epithelial cell	kidney proximal straight tubule epithelial cell	CL:1000839	ProxStraightTubule	4			epithelial cell of proximal tubule	CL:0002306	epithelial cell of nephron	CL:1000449	epithelial cell	CL:0000066	cell	CL:0000548
+kidney distal convoluted tubule epithelial cell	kidney distal convoluted tubule epithelial cell	CL:1000849	DistalConvTubule	4			epithelial cell of distal tubule	CL:0002305	epithelial cell of nephron	CL:1000449	epithelial cell	CL:0000066	cell	CL:0000548
+kidney capillary endothelial cell	kidney capillary endothelial cell	CL:1000892	KidneyCapillaryEndo	4			blood vessel endothelial cell	CL:0000071	endothelial cell of vascular tree	CL:0002139	endothelial cell	CL:0000115	cell	CL:0000548
+kidney loop of Henle epithelial cell	kidney loop of Henle epithelial cell	CL:1000909	HenleTubule	3					epithelial cell of nephron	CL:1000449	epithelial cell	CL:0000066	cell	CL:0000548
+kidney collecting duct cell	kidney collecting duct cell	CL:1001225	KidneyDuct	3					duct epithelial cell	CL:0000068	epithelial cell	CL:0000066	cell	CL:0000548
+bladder cell	bladder cell	CL:1001319	BladderCell	2							lower urinary tract cell	CL:1000600	cell	CL:0000548
+bladder urothelial cell	bladder urothelial cell	CL:1001428	BladderUrothelial	3					bladder cell	CL:1001319	lower urinary tract cell	CL:1000600	cell	CL:0000548
+lung endothelial cell	lung endothelial cell	CL:1001567	LungEndothelial	4			blood vessel endothelial cell	CL:0000071	endothelial cell of vascular tree	CL:0002139	endothelial cell	CL:0000115	cell	CL:0000548
+mammary gland glandular cell	mammary gland glandular cell	CL:1001586	MammaryGlandular	3					glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	cell	CL:0000548
+lung macrophage	lung macrophage	CL:1001603	LungMacrophage	4			macrophage	CL:0000235	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
+bone marrow hematopoietic cell	bone marrow hematopoietic cell	CL:1001610	BoneMarrowHemato	2							hematopoietic cell	CL:0000988	cell	CL:0000548
+microvascular endothelial cell	microvascular endothelial cell	CL:2000008	MicroVascEndo	4			blood vessel endothelial cell	CL:0000071	endothelial cell of vascular tree	CL:0002139	endothelial cell	CL:0000115	cell	CL:0000548
+cerebellum basket cell	cerebellum basket cell	CL:2000027	CerebellumBasket	5	basket cell	CL:0000118	central nervous system neuron	CL:2000029	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+central nervous system neuron	central nervous system neuron	CL:2000029	CNSNeuron	3					neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+brain pericyte	brain pericyte	CL:2000043	BrainPericyte	4			central nervous system pericyte	CL:0002575	pericyte	CL:0000669	connective tissue cell	CL:0002320	cell	CL:0000548
+inflammatory monocyte		DB:0000001	InflamMonocyte	4			monocyte	CL:0000576	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
+"exhausted-like CD4-positive, alpha-beta T cell"		DB:0000002	ExhCD4Tcell	5	"CD4-positive, alpha-beta T cell"	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+"proliferating CD8-positive, alpha-beta T cell"		DB:0000003	ProlifCD8Tcell	5	"CD8-positive, alpha-beta T cell"	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+CCR7-positive myeloid dendritic cell		DB:0000004	cDC_CCR7	4			myeloid dendritic cell	CL:0000782	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
+"exhausted-like CD8-positive, alpha-beta T cell"		DB:0000005	ExhCD8Tcell	5	"CD8-positive, alpha-beta T cell"	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
 melanocytic melanoma cell		DB:0000006	MelMelanoma	2							malignant cell	CL:0001064	neoplastic cell	CL:0001063
-IL7R-max CD8-positive, alpha-beta cytotoxic T cell		DB:0000007	CD8Tcell_IL7Rmax	5	CD8-positive, alpha-beta T cell	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-IL7R-max CD4-positive, alpha-beta cytotoxic T cell		DB:0000040	CD4Tcell_IL7Rmax	5	CD4-positive, alpha-beta T cell	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-doublet		DB:0000008	Doublet	1									animal cell	CL:0000548
-immature enterocyte		DB:0000009	ImmatureEnterocyte	5	enterocyte	CL:0000584	intestinal epithelial cell	CL:0002563	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	animal cell	CL:0000548
-immature goblet cell		DB:0000010	ImmatureGoblet	4			goblet cell	CL:0000160	glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	animal cell	CL:0000548
-inflammatory fibroblast		DB:0000011	InflamFibroblast	3					fibroblast	CL:0000057	connective tissue cell	CL:0002320	animal cell	CL:0000548
-artifact		DB:0000012	Artifact	1									animal cell	CL:0000548
-proliferating neuron		DB:0000013	ProlifNeuron	3					neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-myeloid T cell doublet		DB:0000014	MyeloTcell	2							hematopoietic cell	CL:0000988	animal cell	CL:0000548
-natural killer or T cell		DB:0000015	NKorTcell	3					lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-newly formed oligodendrocyte		DB:0000016	NFOligodendrocyte	5	oligodendrocyte	CL:0000128	macrogial cell	CL:0000126	glial cell	CL:0000125	neural cell	CL:0002319	animal cell	CL:0000548
-nonhematopoietic cell		DB:0000017	NonHematopoietic	1									animal cell	CL:0000548
-proliferating B cell		DB:0000018	ProlifBcell	4			B cell	CL:0000236	lymphocyte of B lineage	CL:0000945	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-proliferating monocyte		DB:0000020	ProlifMonocyte	3			monocyte	CL:0000576	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-proliferating T cell		DB:0000021	ProlifTcell	3			T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-proliferating CD4-positive, alpha-beta T cell		DB:0000022	ProlifCD4Tcell	5	CD4-positive, alpha-beta T cell	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-proliferating transit amplifying cell		DB:0000023	ProlifTAmplifying	5	transit amplifying cell	CL:0009010	intestinal epithelial cell	CL:0002563	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	animal cell	CL:0000548
-transit amplifying cell		CL:0009010	TAmplifying	4			intestinal epithelial cell	CL:0002563	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	animal cell	CL:0000548
-SLC17A7-positive neuron		DB:0000025	Neuron_SLC17A7	4			glutamatergic neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-SLC17A6-positive neuron		DB:0000026	Neuron_SLC17A6	4			glutamatergic neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-SLC17A6_SLC17A7-positive neuron		DB:0000027	Neuron_SLC17A6_SLC17A7	4			glutamatergic neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-GAD1-positive neuron		DB:0000028	Neuron_GAD1	4			GABAergic neuron	CL:0000617	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-GAD1_GAD2-positive neuron		DB:0000029	Neuron_GAD1_GAD2	4			GABAergic neuron	CL:0000617	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-GAD1_GAD2_VIP-positive neuron		DB:0000041	Neuron_GAD1_GAD2_VIP	4			GABAergic neuron	CL:0000617	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-MGP-positive endothelial stalk cell		DB:0000030	StalkEndothelial_MGP	5	endothelial stalk cell	CL:0002671	blood vessel endothelial cell	CL:0000071	endothelial cell of vascular tree	CL:0002139	endothelial cell	CL:0000115	animal cell	CL:0000548
-GAD1_GAD2_SST-positive neuron		DB:0000042	Neuron_GAD1_GAD2_SST	4			GABAergic neuron	CL:0000617	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-GAD1_GAD2_PVALB-positive neuron		DB:0000032	Neuron_GAD1_GAD2_PVALB	4			GABAergic neuron	CL:0000617	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-GAD1_GAD2_CPLX3-positive neuron		DB:0000033	Neuron_GAD1_GAD2_CPLX3	4			GABAergic neuron	CL:0000617	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-GAD1_GAD2_HTR3A-positive neuron		DB:0000034	Neuron_GAD1_GAD2_HTR3A	4			GABAergic neuron	CL:0000617	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-GAD1_GAD2_TAC2-positive neuron		DB:0000035	Neuron_GAD1_GAD2_TAC2	4			GABAergic neuron	CL:0000617	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-SLC17A8-positive neuron		DB:0000036	Neuron_SLC17A8	4			glutamatergic neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-enterocyte progenitor		DB:0000037	EnterocytePC	4			intestinal epithelial cell	CL:0002563	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	animal cell	CL:0000548
-GAD1_GAD2_ID2-positive neuron		DB:0000038	Neuron_GAD1_GAD2_ID2	4			GABAergic neuron	CL:0000617	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-SATB2_EBF3_GLYT1-positive amacrine cell		DB:0000039	Amacrine_SATB2_EBF3_GLYT1	3					amacrine cell	CL:0000561	neural cell	CL:0002319	animal cell	CL:0000548
+"IL7R-max CD8-positive, alpha-beta cytotoxic T cell"		DB:0000007	CD8Tcell_IL7Rmax	5	"CD8-positive, alpha-beta T cell"	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+"IL7R-max CD4-positive, alpha-beta cytotoxic T cell"		DB:0000040	CD4Tcell_IL7Rmax	5	"CD4-positive, alpha-beta T cell"	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+doublet		DB:0000008	Doublet	1									cell	CL:0000548
+immature enterocyte		DB:0000009	ImmatureEnterocyte	5	enterocyte	CL:0000584	intestinal epithelial cell	CL:0002563	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	cell	CL:0000548
+immature goblet cell		DB:0000010	ImmatureGoblet	4			goblet cell	CL:0000160	glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	cell	CL:0000548
+inflammatory fibroblast		DB:0000011	InflamFibroblast	3					fibroblast	CL:0000057	connective tissue cell	CL:0002320	cell	CL:0000548
+artifact		DB:0000012	Artifact	1									cell	CL:0000548
+proliferating neuron		DB:0000013	ProlifNeuron	3					neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+myeloid T cell doublet		DB:0000014	MyeloTcell	2							hematopoietic cell	CL:0000988	cell	CL:0000548
+natural killer or T cell		DB:0000015	NKorTcell	3					lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+newly formed oligodendrocyte		DB:0000016	NFOligodendrocyte	5	oligodendrocyte	CL:0000128	macroglial cell	CL:0000126	glial cell	CL:0000125	neural cell	CL:0002319	cell	CL:0000548
+nonhematopoeitic cell		DB:0000017	NonHematopoeitic	1									cell	CL:0000548
+proliferating B cell		DB:0000018	ProlifBcell	4			B cell	CL:0000236	lymphocyte of B lineage	CL:0000945	hematopoietic cell	CL:0000988	cell	CL:0000548
+proliferating monocyte		DB:0000020	ProlifMonocyte	4			monocyte	CL:0000576	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
+proliferating T cell		DB:0000021	ProlifTcell	4			T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+"proliferating CD4-positive, alpha-beta T cell"		DB:0000022	ProlifCD4Tcell	5	"CD4-positive, alpha-beta T cell"	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+proliferating transit amplifying cell		DB:0000023	ProlifTAmplifying	5	transit amplifying cell	DB:0000024	intestinal epithelial cell	CL:0002563	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	cell	CL:0000548
+transit amplifying cell		CL:0009010	TAmplifying	4			intestinal epithelial cell	CL:0002563	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	cell	CL:0000548
+SLC17A7-positive neuron		DB:0000025	Neuron_SLC17A7	4			glutamatergic neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+SLC17A6_SLC17A8-positive neuron		DB:0000057	Neuron_SLC17A6_SLC17A8	4			glutamatergic neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+SLC17A6_PVALB-positive neuron		DB:0000085	Neuron_SLC17A6_PVALB	4			glutamatergic neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+GAD1-positive neuron		DB:0000028	Neuron_GAD1	4			GABAergic neuron	CL:0000617	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+GAD1_GAD2-positive neuron		DB:0000029	Neuron_GAD1_GAD2	4			GABAergic neuron	CL:0000617	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+GAD1_GAD2_VIP-positive neuron		DB:0000041	Neuron_GAD1_GAD2_VIP	4			GABAergic neuron	CL:0000617	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+MGP-positive endothelial stalk cell		DB:0000030	StalkEndothelial_MGP	5	endothelial stalk cell	CL:0002671	blood vessel endothelial cell	CL:0000071	endothelial cell of vascular tree	CL:0002139	endothelial cell	CL:0000115	cell	CL:0000548
+GAD1_GAD2_SST-positive neuron		DB:0000042	Neuron_GAD1_GAD2_SST	4			GABAergic neuron	CL:0000617	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+GAD1_GAD2_PVALB-positive neuron		DB:0000032	Neuron_GAD1_GAD2_PVALB	4			GABAergic neuron	CL:0000617	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+GAD1_GAD2_CPLX3-positive neuron		DB:0000033	Neuron_GAD1_GAD2_CPLX3	4			GABAergic neuron	CL:0000617	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+GAD1_GAD2_HTR3A-positive neuron		DB:0000034	Neuron_GAD1_GAD2_HTR3A	4			GABAergic neuron	CL:0000617	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+GAD1_GAD2_TAC2-positive neuron		DB:0000035	Neuron_GAD1_GAD2_TAC2	4			GABAergic neuron	CL:0000617	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+SLC17A8-positive neuron		DB:0000036	Neuron_SLC17A8	4			glutamatergic neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+enterocyte progenitor		DB:0000037	EnterocytePC	4			intestinal epithelial cell	CL:0002563	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	cell	CL:0000548
+GAD1_GAD2_ID2-positive neuron		DB:0000038	Neuron_GAD1_GAD2_ID2	4			GABAergic neuron	CL:0000617	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+SATB2_EBF3_GLYT1-positive amacrine cell		DB:0000039	Amacrine_SATB2_EBF3_GLYT1	3					amacrine cell	CL:0000561	neural cell	CL:0002319	cell	CL:0000548
 epithelial cell derived cell line	epithelial cell derived cell line	EFO:0001641	EpithelialCellLine	1									cultured cell	CL:0000010
 U-87 MG	U-87 MG	EFO:0005237	U87MG	2							epithelial cell derived cell line	EFO:0001641	cultured cell	CL:0000010
-embryonic cell	embryonic cell	CL:0002321	Embryonic	1									animal cell	CL:0000548
-immature conventional dendritic cell	immature conventional dendritic cell	CL:0000840	ImmaturecDC	4			myeloid dendritic cell	CL:0002394	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-activated T cell		DB:0000043	ActTcell	4			T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-CD8-positive, alpha-beta memory T cell	CD8-positive, alpha-beta memory T cell	CL:0000909	MemCD8Tcell	5	CD8-positive, alpha-beta T cell	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-group 1 innate lymphoid cell	group 1 innate lymphoid cell	CL:0001067	ILC1	4			innate lymphoid cell	CL:0001065	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-group 2 innate lymphoid cell	group 2 innate lymphoid cell	CL:0001069	ILC2	4			innate lymphoid cell	CL:0001065	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-group 3 innate lymphoid cell	group 3 innate lymphoid cell	CL:0001071	ILC3	4			innate lymphoid cell	CL:0001065	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-IgA plasma cell	IgA plasma cell	CL:0000987	IgAPlasma	4			plasma cell	CL:0000786	lymphocyte of B lineage	CL:0000945	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-IgG plasma cell	IgG plasma cell	CL:0000985	IgGPlasma	4			plasma cell	CL:0000786	lymphocyte of B lineage	CL:0000945	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-IgM or IgA plasma cell		DB:0000044	IgMorIgAPlasma	4			plasma cell	CL:0000786	lymphocyte of B lineage	CL:0000945	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-IgM plasma cell	IgM plasma cell	CL:0000986	IgMPlasma	4			plasma cell	CL:0000786	lymphocyte of B lineage	CL:0000945	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-naive T cell	naive T cell	CL:0000898	NaiTcell	4			T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
+embryonic cell	embryonic cell	CL:0002321	Embryonic	1									cell	CL:0000548
+immature conventional dendritic cell	immature conventional dendritic cell	CL:0000840	ImmaturecDC	4			myeloid dendritic cell	CL:0002394	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
+activated T cell		DB:0000043	ActTcell	4			T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+"CD8-positive, alpha-beta memory T cell"	"CD8-positive, alpha-beta memory T cell"	CL:0000909	MemCD8Tcell	5	"CD8-positive, alpha-beta T cell"	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+group 1 innate lymphoid cell	group 1 innate lymphoid cell	CL:0001067	ILC1	4			innate lymphoid cell	CL:0001065	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+group 2 innate lymphoid cell	group 2 innate lymphoid cell	CL:0001069	ILC2	4			innate lymphoid cell	CL:0001065	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+group 3 innate lymphoid cell	group 3 innate lymphoid cell	CL:0001071	ILC3	4			innate lymphoid cell	CL:0001065	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+IgA plasma cell	IgA plasma cell	CL:0000987	IgAPlasma	4			plasma cell	CL:0000786	lymphocyte of B lineage	CL:0000945	hematopoietic cell	CL:0000988	cell	CL:0000548
+IgG plasma cell	IgG plasma cell	CL:0000985	IgGPlasma	4			plasma cell	CL:0000786	lymphocyte of B lineage	CL:0000945	hematopoietic cell	CL:0000988	cell	CL:0000548
+IgM or IgA plasma cell		DB:0000044	IgMorIgAPlasma	4			plasma cell	CL:0000786	lymphocyte of B lineage	CL:0000945	hematopoietic cell	CL:0000988	cell	CL:0000548
+IgM plasma cell	IgM plasma cell	CL:0000986	IgMPlasma	4			plasma cell	CL:0000786	lymphocyte of B lineage	CL:0000945	hematopoietic cell	CL:0000988	cell	CL:0000548
+naive T cell	naive T cell	CL:0000898	NaiTcell	4			T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
 CMS1 colorectal cancer cell		DB:0000045	CMS1Colorectal	3					colorectal cancer cell	DB:0000049	malignant cell	CL:0001064	neoplastic cell	CL:0001063
 CMS2 colorectal cancer cell		DB:0000046	CMS2Colorectal	3					colorectal cancer cell	DB:0000049	malignant cell	CL:0001064	neoplastic cell	CL:0001063
 CMS3 colorectal cancer cell		DB:0000047	CMS3Colorectal	3					colorectal cancer cell	DB:0000049	malignant cell	CL:0001064	neoplastic cell	CL:0001063
 CMS4 colorectal cancer cell		DB:0000048	CMS4Colorectal	3					colorectal cancer cell	DB:0000049	malignant cell	CL:0001064	neoplastic cell	CL:0001063
-colorectal cancer cell		DB:0000049	ColorectalCancer 	2							malignant cell	CL:0001064	neoplastic cell	CL:0001063
-enteric glial cell		DB:0000050	EntericGlial	3					glial cell	CL:0000125	neural cell	CL:0002319	animal cell	CL:0000548
-endothelial cell of lymphatic vessel	endothelial cell of lymphatic vessel	CL:0002138	EndothelialLymph	3					endothelial cell of vascular tree	CL:0002139	endothelial cell	CL:0000115	animal cell	CL:0000548
-MSR1-positive macrophage		DB:0000056	Macrophage_MSR1	4			macrophage	CL:0000235	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-MARCO-positive macrophage		DB:0000054	Macrophage_MARCO	4			macrophage	CL:0000235	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-CXCL9-positive macrophage		DB:0000055	Macrophage_CXCL9	4			macrophage	CL:0000235	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-choroid plexus epithelial cell	choroid plexus epithelial cell	CL:0000706	ChoroidPlexusEpithelial	4			ependymal cell	CL:0000065	ciliated epithelial cell	CL:0000067	epithelial cell	CL:0000066	animal cell	CL:0000548
-exhausted B cell		DB:0000051	ExhBcell	4			B cell	CL:0000236	lymphocyte of B lineage	CL:0000945	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-mesothelial cell	mesothelial cell	CL:0000077	Mesothelial	1									animal cell	CL:0000548
-proliferating myeloid leukocyte		DB:0000052	ProlifMyeloid	3					myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-proliferating myeloid dendritic cell		DB:0000053	ProlifcDC	4			myeloid dendritic cell	CL:0000782	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-SLC17A6_SLC17A8-positive neuron		DB:0000057	Neuron_SLC17A6_SLC17A8	4			glutamatergic neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-SLC17A7_GABRA6-positive neuron		DB:0000058	Neuron_SLC17A7_GABRA6	4			glutamatergic neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-SLC17A7_RBFOX1_NEUROD2-positive neuron		DB:0000059	Neuron_SLC17A7_RBFOX1_NEUROD2	4			glutamatergic neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-melanocyte	melanocyte	CL:0000148	Melanocyte	1									animal cell	CL:0000548
-platelet	platelet	CL:0000233	Platelet	2							hematopoietic cell	CL:0000988	animal cell	CL:0000548
-proliferating epithelial fate stem cell		DB:0000073	ProlifEpithelialStem	5	epithelial fate stem cell	CL:0000036	somatic stem cell	CL:0000723	stem cell	CL:0000034	precursor cell	CL:0011115	animal cell	CL:0000548
-proliferating enterocyte progenitor		DB:0000074	ProlifEnterocytePC	5	enterocyte progenitor	DB:0000037	intestinal epithelial cell	CL:0002563	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	animal cell	CL:0000548
-proliferating hematopoietic cell		DB:0000075	ProlifHematopoietic	2							hematopoietic cell	CL:0000988	animal cell	CL:0000548
-secretory progenitor		DB:0000076	SecretoryPC	3					glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	animal cell	CL:0000548
-B T cell doublet		DB:0000077	BTcell	2							hematopoietic cell	CL:0000988	animal cell	CL:0000548
-ACE-positive macrophage		DB:0000078	Macrophage_ACE	4			macrophage	CL:0000235	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-FOLR2-positive macrophage		DB:0000079	Macrophage_FOLR2	4			macrophage	CL:0000235	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-TREM2-positive macrophage		DB:0000080	Macrophage_TREM2	4			macrophage	CL:0000235	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-RXRG-positive macrophage		DB:0000081	Macrophage_RXRG	4			macrophage	CL:0000235	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-CD8-positive, alpha-beta resource T cell		DB:0000082	ResourceCD8Tcell	5	CD8-positive, alpha-beta T cell	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-monocyte or dendritic cell		DB:0000083	MonocyteDC	3					myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-CD209-positive myeloid dendritic cell		DB:0000084	cDC_CD209	4			myeloid dendritic cell	CL:0000782	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-cardiac endothelial cell	cardiac endothelial cell	CL:0010008	CardialEndothelial	2							endothelial cell	CL:0000115	animal cell	CL:0000548
-sensory neuron	sensory neuron	CL:0000101	SensoryNeuron	3					neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-GAD1_GAD1_SV2C-positive neuron		DB:0000068	Neuron_GAD1_GAD1_SV2C	4			GABAergic neuron	CL:0000617	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-GAD1_GAD2_CPLX3_SV2C-positive neuron		DB:0000069	Neuron_GAD1_GAD2_CPLX3_SV2C	4			GABAergic neuron	CL:0000617	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-GAD1_GAD2_SV2C-positive neuron		DB:0000071	Neuron_GAD1_GAD2_SV2C	4			GABAergic neuron	CL:0000617	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-GAD1_PVALB-positive neuron		DB:0000072	Neuron_GAD1_PVALB	4			GABAergic neuron	CL:0000617	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-SLC17A7_CUX2-positive neuron		DB:0000060	Neuron_SLC17A7_CUX2	4			glutamatergic neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-SLC17A7_CUX2_RORB-positive neuron		DB:0000061	Neuron_SLC17A7_CUX2_RORB	4			glutamatergic neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-SLC17A7_RORB_FOXP_DCC-positive neuron		DB:0000063	Neuron_SLC17A7_RORB_FOXP_DCC	4			glutamatergic neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-SLC17A7_RORB_FOXP2-positive neuron		DB:0000062	Neuron_SLC17A7_RORB_FOXP2	4			glutamatergic neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-SLC17A7_RORB_FOXP2_DCC-positive neuron		DB:0000070	Neuron_SLC17A7_RORB_FOXP2_DCC	4			glutamatergic neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-SLC17A7_THEMIS-positive neuron		DB:0000064	Neuron_SLC17A7_THEMIS	4			glutamatergic neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-SLC17A7_THEMIS_DCC-positive neuron		DB:0000065	Neuron_SLC17A7_THEMIS_DCC	4			glutamatergic neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-SLC17A7_TLE4_FOXP2-positive neuron		DB:0000066	Neuron_SLC17A7_TLE4_FOXP2	4			glutamatergic neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-SLC17A7_TLE4_FOXP2_DCC-positive neuron		DB:0000067	Neuron_SLC17A7_TLE4_FOXP2_DCC	4			glutamatergic neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-chondrocyte	chondrocyte	CL:0000138	Chondrocyte	2							connective tissue cell	CL:0002320	animal cell	CL:0000548
-cortical cell of adrenal gland	cortical cell of adrenal gland	CL:0002097	Adrenocortical	3					glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	animal cell	CL:0000548
-chromaffin cell	chromaffin cell	CL:0000166 	Chromaffin	4			neuroendocrine cell	CL:0000165	endocrine cell	CL:0000163	secretory cell	CL:0000151	animal cell	CL:0000548
-corneal epithelial cell	corneal epithelial cell	CL:0000575	CornealEpithelial	3					ecto-epithelial cell	CL:0002077	epithelial cell	CL:0000066	animal cell	CL:0000548
-enteric neuron	enteric neuron	CL:0007011	EntericNeuron	3					neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-cardiocyte	cardiocyte	CL:0002494	Cardiocyte	2									animal cell	CL:0000548
-extravillous trophoblast	extravillous trophoblast	CL:0008036	ExtravillousTrophoblast	3					trophoblast cell	CL:0000351	extraembryonic cell	CL:0000349	animal cell	CL:0000548
-trophoblast cell	trophoblast cell	CL:0000351	Trophoblast	2							extraembryonic cell	CL:0000349	animal cell	CL:0000548
-extraembryonic cell	extraembryonic cell	CL:0000349	Extraembryonic	1									animal cell	CL:0000548
-hepatoblast	hepatoblast	CL:0005026	Hepatoblast	4			multi fate stem cell	CL:0000048	stem cell	CL:0000034	precursor cell	CL:0011115	animal cell	CL:0000548
-inhibitory interneuron	inhibitory interneuron	CL:0000498	InhibitoryInterneuron	4			interneuron	CL:0000099	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-lens fiber cell	lens fiber cell	CL:0011004	LensFiber	3					vertebrate lens cell	CL:0002222	epithelial cell	CL:0000066	animal cell	CL:0000548
-vertebrate lens cell	vertebrate lens cell	CL:0002222	VertebrateLens	2							epithelial cell	CL:0000066	animal cell	CL:0000548
-chief cell of parathyroid gland	chief cell of parathyroid gland	CL:0000446	ParathyroidGlandChief	4			epithelial cell of parathyroid gland	CL:0002260	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	animal cell	CL:0000548
-epithelial cell of parathyroid gland	epithelial cell of parathyroid gland	CL:0002260	ParathyroidGlandEpithelial	3					endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	animal cell	CL:0000548
-retinal progenitor cell	retinal progenitor cell	CL:0002672	RetinalProgenitor	4			multi fate stem cell	CL:0000048	stem cell	CL:0000034	precursor cell	CL:0011115	animal cell	CL:0000548
-squamous epithelial cell	squamous epithelial cell	CL:0000076	SquamousEpithelial	2							epithelial cell	CL:0000066	animal cell	CL:0000548
-epithelial cell of thymus	epithelial cell of thymus	CL:0002293	ThymusEpithelial	3					endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	animal cell	CL:0000548
-thymocyte	thymocyte	CL:0000893	Thymocyte	5	immature T cell	CL:0002420	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-trophoblast giant cell	trophoblast giant cell	CL:0002488	TrophoblastGiant	3					trophoblast cell	CL:0000351	extraembryonic cell	CL:0000349	animal cell	CL:0000548
-visceromotor neuron	visceromotor neuron	CL:0005025	VisceromotorN	5	motor neuron	CL:0000100	efferent neuron	CL:0000527	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-motor neuron	motor neuron	CL:0000100	MotorN	4			efferent neuron	CL:0000527	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-efferent neuron	efferent neuron	CL:0000527	EfferentN	3					neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-fat cell	fat cell	CL:0000136	Adipocyte	2							connective tissue cell	CL:0002320	animal cell	CL:0000548
-epicardial adipocyte	epicardial adipocyte	CL:1000309	EpicardialAdipocyte	3					fat cell	CL:0000136 	connective tissue cell	CL:0002320	animal cell	CL:0000548
-SLC17A6_PVALB-positive neuron		DB:0000085	Neuron_SLC17A6_PVALB	4			glutamatergic neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-proliferating natural killer cell		DB:0000086	ProlifNKcell	5	natural killer cell	CL:0000623	innate lymphoid cell	CL:0001065	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-B myeloid cell doublet		DB:0000087	BMyeloid	2							hematopoietic cell	CL:0000988	animal cell	CL:0000548
-BEST4+ intestinal epithelial cell, human	BEST4+ intestinal epithelial cell, human	CL:4030026	BEST4enterocyte	5	enterocyte	CL:0000584	intestinal epithelial cell	CL:0002563	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	animal cell	CL:0000548
-T follicular helper cell	T follicular helper cell	CL:0002038	FollicularTh	5	CD4-positive, alpha-beta T cell	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-capillary endothelial cell	capillary endothelial cell	CL:0002144	CapillaryEndothelial	4			blood vessel endothelial cell	CL:0000071	endothelial cell of vascular tree	CL:0002139	endothelial cell	CL:0000115	animal cell	CL:0000548
-colon macrophage	colon macrophage	CL:0009038	ColonMacrophage	4			macrophage	CL:0000235	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	animal cell	CL:0000548
-endothelial cell of artery	endothelial cell of artery	CL:1000413	EndothelialArtery	4			blood vessel endothelial cell	CL:0000071	endothelial cell of vascular tree	CL:0002139	endothelial cell	CL:0000115	animal cell	CL:0000548
-tuft cell of colon	tuft cell of colon	CL:0009041	TuftColon	5	brush cell of epithelium proper of large intestine	CL:0002203	brush cell	CL:0002204	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	animal cell	CL:0000548
-vein endothelial cell	vein endothelial cell	CL:0002543	VeinEndothelial	4			blood vessel endothelial cell	CL:0000071	endothelial cell of vascular tree	CL:0002139	endothelial cell	CL:0000115	animal cell	CL:0000548
-molecular layer interneuron		DB:0000089	MLInterneuron	5	CNS interneuron	CL:0000402	central nervous system neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-CNS interneuron	CNS interneuron	CL:0000402	CNSInterneuron	4			central nervous system neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-unipolar brush cell	unipolar brush cell	CL:4023161	UnipolarBrush	5	CNS interneuron	CL:0000402	central nervous system neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-purkinje layer interneuron		DB:0000090	PLInterneuron	5	CNS interneuron	CL:0000402	central nervous system neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-hepatic stellate cell	hepatic stellate cell	CL:0000632	HepStellate	3					fibroblast	CL:0000057	connective tissue cell	CL:0002320	animal cell	CL:0000548
-centrilobular region hepatocyte	centrilobular region hepatocyte	CL:0019029	CentrilobularHepatocyte	3					hepatocyte	CL:0000182	epithelial cell	CL:0000066	animal cell	CL:0000548
-midzonal region hepatocyte	midzonal region hepatocyte	CL:0019028	MidzonalHepatocyte	3					hepatocyte	CL:0000182	epithelial cell	CL:0000066	animal cell	CL:0000548
-periportal region hepatocyte	periportal region hepatocyte	CL:0019026	PeriportalHepatocyte	3					hepatocyte	CL:0000182	epithelial cell	CL:0000066	animal cell	CL:0000548
-enteric glial precursor cell		DB:0000091	EntericGlialPC	4			enteric glial cell	DB:0000050	glial cell	CL:0000125	neural cell	CL:0002319	animal cell	CL:0000548
-glandular cell of stomach	glandular cell of stomach	CL:0002659	GlandularStomach	3					glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	animal cell	CL:0000548
-mucous cell of stomach	mucous cell of stomach	CL:0002180	MucousStomach	4			glandular cell of stomach	CL:0002659	glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	animal cell	CL:0000548
-parietal cell	parietal cell	CL:0000162	ParietalCell	4			glandular cell of stomach	CL:0002659	glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	animal cell	CL:0000548
-peptic cell	peptic cell	CL:0000155	PepticCell	4			glandular cell of stomach	CL:0002659	glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	animal cell	CL:0000548
-stomach enteroendocrine cell	stomach enteroendocrine cell	CL:1001517	StomachEnteroendocrine	4			glandular cell of stomach	CL:0002659	glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	animal cell	CL:0000548
-skeletal muscle fiber	skeletal muscle fiber	CL:0008002	SkeletalMuscle	3					muscle cell	CL:0000187	contractile cell	CL:0000183	animal cell	CL:0000548
-type I muscle cell	type I muscle cell	CL:0002211	TypeIMuscle	4			skeletal muscle fiber	CL:0008002	muscle cell	CL:0000187	contractile cell	CL:0000183	animal cell	CL:0000548
-type II muscle cell	type II muscle cell	CL:0002212	TypeIIMuscle	4			skeletal muscle fiber	CL:0008002	muscle cell	CL:0000187	contractile cell	CL:0000183	animal cell	CL:0000548
-glandular cell of esophagus	glandular cell of esophagus	CL:0002657	EsophagusGlandular	3					glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	animal cell	CL:0000548
-mesothelial fibroblast of the leptomeninx	mesothelial fibroblast of the leptomeninx	CL:4023058	MesoFibroblastLeptomeninx	2							neural cell	CL:0002319	animal cell	CL:0000548
-vascular leptomeningeal cell	vascular leptomeningeal cell	CL:4023051	VascLeptomeningeal	3					mesothelial fibroblast of the leptomeninx	CL:4023058	neural cell	CL:0002319	animal cell	CL:0000548
-chromophil cell of anterior pituitary gland	chromophil cell of anterior pituitary gland	CL:0000637	ChromophilAnteriorPituitary	2							neural cell	CL:0002319	animal cell	CL:0000548
-acidophil cell of pars distalis of adenohypophysis	acidophil cell of pars distalis of adenohypophysis	CL:0000638	AcidophilParsDistalis	3					chromophil cell of anterior pituitary gland	CL:0000637	neural cell	CL:0002319	animal cell	CL:0000548
-basophil cell of pars distalis of adenohypophysis	basophil cell of pars distalis of adenohypophysis	CL:0000639	BasophilParsDistalis	3					chromophil cell of anterior pituitary gland	CL:0000637	neural cell	CL:0002319	animal cell	CL:0000548
-mammotroph	mammotroph	CL:0002311	Mammotroph	4			acidophil cell of pars distalis of adenohypophysis	CL:0000638	chromophil cell of anterior pituitary gland	CL:0000637	neural cell	CL:0002319	animal cell	CL:0000548
-somatotroph	somatotroph	CL:0002312	Somatotroph	4			acidophil cell of pars distalis of adenohypophysis	CL:0000638	chromophil cell of anterior pituitary gland	CL:0000637	neural cell	CL:0002319	animal cell	CL:0000548
-mammosomatotroph	mammosomatotroph	CL:0002310	Mammosomatotroph	4			acidophil cell of pars distalis of adenohypophysis	CL:0000638	chromophil cell of anterior pituitary gland	CL:0000637	neural cell	CL:0002319	animal cell	CL:0000548
-corticotroph	corticotroph	CL:0002309	Corticotroph	4			basophil cell of pars distalis of adenohypophysis		CL:0000639	CL:0000637	neural cell	CL:0002319	animal cell	CL:0000548
-gonadtroph	gonadtroph	CL:0000437	Gonadtroph	4			basophil cell of pars distalis of adenohypophysis		CL:0000639	CL:0000637	neural cell	CL:0002319	animal cell	CL:0000548
-thyrotroph	thyrotroph	CL:0000476	Thyrotroph	4			basophil cell of pars distalis of adenohypophysis		CL:0000639	CL:0000637	neural cell	CL:0002319	animal cell	CL:0000548
-melanotroph		DB:0000092	Melanotroph	4			basophil cell of pars distalis of adenohypophysis		CL:0000639	CL:0000637	neural cell	CL:0002319	animal cell	CL:0000548
-sst GABAergic cortical interneuron	sst GABAergic cortical interneuron	CL:4023017	GABAergicInterneuron_SST	4			interneuron	CL:0002306	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-pvalb GABAergic cortical interneuron	pvalb GABAergic cortical interneuron	CL:4023018	GABAergicInterneuron_PVALB	4			interneuron	CL:0002306	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-reelin GABAergic cortical interneuron	reelin GABAergic cortical interneuron	CL:4032001	GABAergicInterneuron_REELIN	4			interneuron	CL:0002306	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-lamp5 GABAergic cortical interneuron	lamp5 GABAergic cortical interneuron	CL:4023011	GABAergicInterneuron_LAMP5	4			interneuron	CL:0002306	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-vip GABAergic cortical interneuron	vip GABAergic cortical interneuron	CL:4023016	GABAergicInterneuron_VIP	4			interneuron	CL:0002306	neuron	CL:0000540	neural cell	CL:0002319	animal cell	CL:0000548
-GABAergic amacrine cell	GABAergic amacrine cell	CL:4030027	GABAergicAmacrine	3					amacrine cell	CL:0000561	neural cell	CL:0002319	animal cell	CL:0000548
-glycinergic amacrine cell	glycinergic amacrine cell	CL:4030028	GlycinergicAmacrine	3					amacrine cell	CL:0000561	neural cell	CL:0002319	animal cell	CL:0000548
-adipocyte progenitor cell		DB:0000093	AdipocytePC	3					fat cell	CL:0000136	connective tissue cell	CL:0002320	animal cell	CL:0000548
-type I cell of adrenal cortex	type I cell of adrenal cortex	CL:0002099	TypeICorticalAdrenal	4			cortical cell of adrenal gland	CL:0002097	glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	animal cell	CL:0000548
-type II cell of adrenal cortex	type II cell of adrenal cortex	CL:0002136	TypeIICorticalAdrenal	4			cortical cell of adrenal gland	CL:0002097	glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	animal cell	CL:0000548
-adrenal medulla chromaffin cell	adrenal medulla chromaffin cell	CL:0000336	AdrenalMedullaChromaffin	5	chromaffin cell	CL:0000166	neuroendocrine cell	CL:0000165	endocrine cell	CL:0000163	secretory cell	CL:0000151	animal cell	CL:0000548
-stromal cell of endometrium	stromal cell of endometrium	CL:0002255	StromalEndometrium	3					stromal cell	CL:0000499	connective tissue cell	CL:0002320	animal cell	CL:0000548
-epithelial cell of thyroid gland	epithelial cell of thyroid gland	CL:0002257	ThyroidGlandEpithelial	3					glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	animal cell	CL:0000548
-thyroid follicular cell	thyroid follicular cell	CL:0002258	ThyroidFollicular	4			epithelial cell of thyroid gland	CL:0002257	glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	animal cell	CL:0000548
-meso-epithelial cell	meso-epithelial cell	CL:0002078	MesoEpithelial	2							epithelial cell	CL:0000066	animal cell	CL:0000548
-follicular cell of ovary	follicular cell of ovary	CL:0002174	OvaryFollicular	3					meso-epithelial cell	CL:0002078	epithelial cell	CL:0000066	animal cell	CL:0000548
-granulosa cell	granulosa cell	CL:0000501	Granulosa	4			follicular cell of ovary	CL:0002174	meso-epithelial cell	CL:0002078	epithelial cell	CL:0000066	animal cell	CL:0000548
-stromal cell of ovary	stromal cell of ovary	CL:0002132	StromalOvary	3					stromal cell	CL:0000499	connective tissue cell	CL:0002320	animal cell	CL:0000548
-theca cell	theca cell	CL:0000503	Theca	4			stromal cell of ovary	CL:0002132	stromal cell	CL:0000499	connective tissue cell	CL:0002320	animal cell	CL:0000548
-luteal cell	luteal cell	CL:0000175	Luteal	4			stromal cell of ovary	CL:0002132	stromal cell	CL:0000499	connective tissue cell	CL:0002320	animal cell	CL:0000548
-ovarian surface epithelial cell	ovarian surface epithelial cell	CL:2000064	OvarianSurfaceEpithelial	2							epithelial cell	CL:0000066	animal cell	CL:0000548
-peg cell	peg cell	CL:4033014	PegCell	2							epithelial cell	CL:0000066	animal cell	CL:0000548
-neurecto-epithelial cell	neurecto-epithelial cell	CL:0000710	NeurectoEpithelial	3					ecto-epithelial cell	CL:0002077	epithelial cell	CL:0000066	animal cell	CL:0000548
-type I cell of carotid body	type I cell of carotid body	CL:0002292	TypeICarotidBody	4			neurecto-epithelial cell	CL:0000710	ecto-epithelial cell	CL:0002077	epithelial cell	CL:0000066	animal cell	CL:0000548
-urothelial cell	urothelial cell	CL:0000731	Urothelial	2							epithelial cell	CL:0000066	animal cell	CL:0000548
-basal cell of urothelium	basal cell of urothelium	CL:1000486	UrothelialBasal	3					urothelial cell	CL:0000731	epithelial cell	CL:0000066	animal cell	CL:0000548
-intermediate cell of urothelium	intermediate cell of urothelium	CL:4030055	UrothelialIntermediate	3					urothelial cell	CL:0000731	epithelial cell	CL:0000066	animal cell	CL:0000548
-umbrella cell of urothelium	umbrella cell of urothelium	CL:4030056	UrothelialUmbrella	3					urothelial cell	CL:0000731	epithelial cell	CL:0000066	animal cell	CL:0000548
-oral mucosa squamous cell	oral mucosa squamous cell	CL:1001576	OralMucosaSquamous	3					squamous epithelial cell	CL:0000076	epithelial cell	CL:0000066	animal cell	CL:0000548
-keratinized cell of the oral	keratinized cell of the oral	CL:0000237	OralMucosaKeratinized	3					ecto-epithelial cell	CL:0002077	epithelial cell	CL:0000066	animal cell	CL:0000548
-serous secreting cell	serous secreting cell	CL:0000313	SerousSecreting	2							secretory cell	CL:0000151	animal cell	CL:0000548
-meningothelial cell	meningothelial cell	CL:0002379	Meningothelial	4			neurecto-epithelial cell	CL:0000710	ecto-epithelial cell	CL:0002077	epithelial cell	CL:0000066	animal cell	CL:0000548
-tendon cell	tendon cell	CL:0000388	Tendon	2							stromal cell	CL:0000499	animal cell	CL:0000548
-fibro/adipogenic progenitor cell	fibro/adipogenic progenitor cell	CL:0009099	FibroAdipogenicProgenitor	2							mesenchymal cell	CL:0008019	animal cell	CL:0000548
-epithelial cell of prostate	epithelial cell of prostate	CL:0002231	ProstateEpithelial	3					endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	animal cell	CL:0000548
-luminal cell of prostate epithelium	luminal cell of prostate epithelium	CL:0002340	LuminalProstateEpithelium	4			epithelial cell of prostate	CL:0002231	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	animal cell	CL:0000548
-clear cell		DB:0000094		3					ionocyte	CL:0005006	epithelial cell	CL:0000066	animal cell	CL:0000548
-renal intercalated cell	renal intercalated cell	CL:0005010	RenalIntercalated	3					epithelial cell of nephron	CL:1000449	epithelial cell	CL:0000066	animal cell	CL:0000548
-renal alpha-intercalated cell	renal alpha-intercalated cell	CL:0005011	RenalAlphaIntercalated	4			renal intercalated cell	CL:0005011	epithelial cell of nephron	CL:1000449	epithelial cell	CL:0000066	animal cell	CL:0000548
-renal beta-intercalated cell	renal beta-intercalated cell	CL:0002201	RenalBetaIntercalated	4			renal intercalated cell	CL:0005011	epithelial cell of nephron	CL:1000449	epithelial cell	CL:0000066	animal cell	CL:0000548
-renal principal cell	renal principal cell	CL:0005009	RenalPrincipal	3					epithelial cell of nephron	CL:1000449	epithelial cell	CL:0000066	animal cell	CL:0000548
-glomerular endothelial cell	glomerular endothelial cell	CL:0002188	GlomerularEndo	2							endothelial cell	CL:0000115	animal cell	CL:0000548
-vasa recta ascending limb cell	vasa recta ascending limb cell	CL:1001131	VasaRectaAscending	4			kidney capillary endothelial cell	CL:1000892	blood vessel endothelial cell	CL:0000071	endothelial cell	CL:0000115	animal cell	CL:0000548
-vasa recta descending limb cell	vasa recta descending limb cell	CL:1001285	VasaRectaDescending	4			kidney capillary endothelial cell	CL:1000892	blood vessel endothelial cell	CL:0000071	endothelial cell	CL:0000115	animal cell	CL:0000548
-peritubular capillary endothelial cell	peritubular capillary endothelial cell	CL:1001033	PeritubularCapillaryEndo	4			kidney capillary endothelial cell	CL:1000892	blood vessel endothelial cell	CL:0000071	endothelial cell	CL:0000115	animal cell	CL:0000548
-renal filtration cell	renal filtration cell	CL:0002522	RenalFiltration	2							secretory cell	CL:0000151	animal cell	CL:0000548
-kidney interstitial myofibroblast	kidney interstitial myofibroblast	CL:1000691	KidneyInterstitialMyofibroblast	3					myofibroblast cell	CL:0000186	contractile cell	CL:0000183	animal cell	CL:0000548
-kidney pelvis urothelial cell	kidney pelvis urothelial cell	CL:1000703	KidneyPelvisUrothelial	3					kidney pelvis urothelial cell	CL:1000703	epithelial cell	CL:0000066	animal cell	CL:0000548
-kidney connecting tubule principal cell	kidney connecting tubule principal cell	CL:4030018	KidneyConnectingTubulePrincipal				renal principal cell	CL:0005009	epithelial cell of nephron	CL:1000449	epithelial cell	CL:0000066	animal cell	CL:0000548
-kidney precursor cell		DB:0000095	KidneyPrecursor	2							precursor cell	CL:0011115	animal cell	CL:0000548
-pronephric nephron cell		DB:0000096	PronephricNephron	3					kidney precursor cell	DB:0000095	precursor cell	CL:0011115	animal cell	CL:0000548
-ureteric bud cell		DB:0000097	UretericBud	3					kidney precursor cell	DB:0000095	precursor cell	CL:0011115	animal cell	CL:0000548
-ureteric bud epithelial cell		DB:0000098	UretericBudEpithelial	4			ureteric bud cell	DB:0000097	kidney precursor cell	DB:0000095	precursor cell	CL:0011115	animal cell	CL:0000548
-renal vesicle cell		DB:0000099	RenalVesicle	3					kidney precursor cell	DB:0000095	precursor cell	CL:0011115	animal cell	CL:0000548
-metanephric mesenchyme cell		DB:0000100	MetanephricMesenchyme	3					kidney precursor cell	DB:0000095	precursor cell	CL:0011115	animal cell	CL:0000548
-S shaped body cell		DB:0000101	SshapedBody	3					kidney precursor cell	DB:0000095	precursor cell	CL:0011115	animal cell	CL:0000548
-kidney collecting duct principal cell	kidney collecting duct principal cell	CL:1001431	KidneyDuctPrincipal	4			kidney collecting duct cell	CL:1001225	duct epithelial cell	CL:0000068	epithelial cell	CL:0000066	animal cell	CL:0000548
-kidney outer medulla collecting duct principal cell	kidney outer medulla collecting duct principal cell	CL:1000716	KidneyOuterMedullaDuctPrincipal	5	kidney collecting duct principal cell	CL:1001431	kidney collecting duct cell	CL:1001225	duct epithelial cell	CL:0000068	epithelial cell	CL:0000066	animal cell	CL:0000548
-kidney inner medulla collecting duct principal cell	kidney inner medulla collecting duct principal cell	CL:1000718	KidneyInnerMedullaDuctPrincipal	5	kidney collecting duct principal cell	CL:1001431	kidney collecting duct cell	CL:1001225	duct epithelial cell	CL:0000068	epithelial cell	CL:0000066	animal cell	CL:0000548
-kidney collecting duct intercalated cell	kidney collecting duct intercalated cell	CL:1001432	KidneyDuctIntercalated	4			kidney collecting duct cell	CL:1001225	duct epithelial cell	CL:0000068	epithelial cell	CL:0000066	animal cell	CL:0000548
-kidney collecting duct beta-intercalated cell	kidney collecting duct beta-intercalated cell	CL:4030005	KidneyDuctBetaIntercalated	5	kidney collecting duct intercalated cell	CL:1001432	kidney collecting duct cell	CL:1001225	duct epithelial cell	CL:0000068	epithelial cell	CL:0000066	animal cell	CL:0000548
-kidney collecting duct alpha-intercalated cell	kidney collecting duct alpha-intercalated cell	CL:4030015	KidneyDuctAlphaIntercalated	5	kidney collecting duct intercalated cell	CL:1001432	kidney collecting duct cell	CL:1001225	duct epithelial cell	CL:0000068	epithelial cell	CL:0000066	animal cell	CL:0000548
-podocyte	podocyte	CL:0000653	Podocyte	4			kidney glomerular epithelial cell	CL:1000510	epithelial cell of nephron	CL:1000449	epithelial cell	CL:0000066	animal cell	CL:0000548
-kidney proximal convoluted tubule epithelial cell	kidney proximal convoluted tubule epithelial cell	CL:1000838	ProxConvolutedTubule	4			epithelial cell of proximal tubule	CL:0002306	epithelial cell of nephron	CL:1000449	epithelial cell	CL:0000066	animal cell	CL:0000548
-kidney loop of Henle ascending limb epithelial cell	kidney loop of Henle ascending limb epithelial cell	CL:1001016	HenleAscendingTubule	4			kidney loop of Henle epithelial cell	CL:1000909	epithelial cell of nephron	CL:1000449	epithelial cell	CL:0000066	animal cell	CL:0000548
-kidney loop of Henle descending limb epithelial cell	kidney loop of Henle descending limb epithelial cell	CL:1001021	HenleDescendingTubule	4			kidney loop of Henle epithelial cell	CL:1000909	epithelial cell of nephron	CL:1000449	epithelial cell	CL:0000066	animal cell	CL:0000548
-papillary tips cell	papillary tips cell	CL:1000597	PapillaryTips	2							epithelial cell	CL:0000066	animal cell	CL:0000548
-glomerular mesangial cell	glomerular mesangial cell	CL:1000742	GlomerularMesangial	4			mesangial cell	CL:0000650	pericyte	CL:0000669	connective tissue cell	CL:0002320	animal cell	CL:0000548
-kidney glomerular epithelial cell	kidney glomerular epithelial cell	CL:1000510	GlomerularEpithelial	3					epithelial cell of nephron	CL:1000449	epithelial cell	CL:0000066	animal cell	CL:0000548
+colorectal cancer cell		DB:0000049	Colorectal	2							malignant cell	CL:0001064	neoplastic cell	CL:0001063
+enteric glial cell		DB:0000050	EntericGlial	3					glial cell	CL:0000125	neural cell	CL:0002319	cell	CL:0000548
+endothelial cell of lymphatic vessel	endothelial cell of lymphatic vessel	CL:0002138	EndothelialLymph	3					endothelial cell of vascular tree	CL:0002139	endothelial cell	CL:0000115	cell	CL:0000548
+MSR1-positive macrophage		DB:0000056	Macrophage_MSR1	4			macrophage	CL:0000235	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
+MARCO-positive macrophage		DB:0000054	Macrophage_MARCO	4			macrophage	CL:0000235	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
+CXCL9-positive macrophage		DB:0000055	Macrophage_CXCL9	4			macrophage	CL:0000235	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
+choroid plexus epithelial cell	choroid plexus epithelial cell	CL:0000706	ChoroidPlexusEpithelial	4			ependymal cell	CL:0000065	ciliated epithelial cell	CL:0000067	epithelial cell	CL:0000066	cell	CL:0000548
+exhausted B cell		DB:0000051	ExhBcell	4			B cell	CL:0000236	lymphocyte of B lineage	CL:0000945	hematopoietic cell	CL:0000988	cell	CL:0000548
+mesothelial cell	mesothelial cell	CL:0000077	Mesothelial	1									cell	CL:0000548
+proliferating myeloid leukocyte		DB:0000052	ProlifMyeloid	3					myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
+proliferating myeloid dendritic cell		DB:0000053	ProlifcDC	4			myeloid dendritic cell	CL:0000782	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
+SLC17A6_SLC17A7-positive neuron		DB:0000027	Neuron_SLC17A6_SLC17A7	4			glutamatergic neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+SLC17A7_DCC-positive neuron		DB:0000063	Neuron_SLC17A7_DCC	4			glutamatergic neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+SLC17A7_GABRA6-positive neuron		DB:0000058	Neuron_SLC17A7_GABRA6	4			glutamatergic neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+melanocyte	melanocyte	CL:0000148	Melanocyte	1									cell	CL:0000548
+platelet	platelet	CL:0000233	Platelet	2							hematopoietic cell	CL:0000988	cell	CL:0000548
+proliferating epithelial fate stem cell		DB:0000073	ProlifEpithelialStem	5	epithelial fate stem cell	CL:0000036	somatic stem cell	CL:0000723	stem cell	CL:0000034	precursor cell	CL:0011115	cell	CL:0000548
+proliferating enterocyte progenitor		DB:0000074	ProlifEnterocytePC	5	enterocyte progenitor	DB:0000037	intestinal epithelial cell	CL:0002563	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	cell	CL:0000548
+proliferating hematopoietic cell		DB:0000075	ProlifHematopoietic	2							hematopoietic cell	CL:0000988	cell	CL:0000548
+secretory cell	secretory cell	CL:0000151	Secretory	1									cell	CL:0000548
+B T cell doublet		DB:0000077	BTcell	2							hematopoietic cell	CL:0000988	cell	CL:0000548
+ACE-positive macrophage		DB:0000078	Macrophage_ACE	4			macrophage	CL:0000235	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
+FOLR2-positive macrophage		DB:0000079	Macrophage_FOLR2	4			macrophage	CL:0000235	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
+TREM2-positive macrophage		DB:0000080	Macrophage_TREM2	4			macrophage	CL:0000235	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
+RXRG-positive macrophage		DB:0000081	Macrophage_RXRG	4			macrophage	CL:0000235	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
+"CD8-positive, alpha-beta resource T cell"		DB:0000082	ResourceCD8Tcell	5	"CD8-positive, alpha-beta T cell"	CL:0000625	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+monocyte or dendritic cell		DB:0000083	MonocyteDC	3					myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
+CD209-positive myeloid dendritic cell		DB:0000084	cDC_CD209	4			myeloid dendritic cell	CL:0000782	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
+cardiac endothelial cell	cardiac endothelial cell	CL:0010008	CardialEndothelial	2							endothelial cell	CL:0000115	cell	CL:0000548
+secretory progenitor		DB:0000076	SecretoryPC	3					glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	cell	CL:0000548
+GAD1_GAD1_SV2C-positive neuron		DB:0000068	Neuron_GAD1_GAD1_SV2C	4			GABAergic neuron	CL:0000617	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+GAD1_GAD2_CPLX3_SV2C-positive neuron		DB:0000069	Neuron_GAD1_GAD2_CPLX3_SV2C	4			GABAergic neuron	CL:0000617	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+GAD1_GAD2_SV2C-positive neuron		DB:0000071	Neuron_GAD1_GAD2_SV2C	4			GABAergic neuron	CL:0000617	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+GAD1_PVALB-positive neuron		DB:0000072	Neuron_GAD1_PVALB	4			GABAergic neuron	CL:0000617	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+SLC17A7_CUX2_RORB-positive neuron		DB:0000061	Neuron_SLC17A7_CUX2_RORB	4			glutamatergic neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+SLC17A6-positive neuron		DB:0000026	Neuron_SLC17A6	4			glutamatergic neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+SLC17A7_RBFOX1_NEUROD2-positive neuron		DB:0000059	Neuron_SLC17A7_RBFOX1_NEUROD2	4			glutamatergic neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+SLC17A7_RORB_FOXP2-positive neuron		DB:0000062	Neuron_SLC17A7_RORB_FOXP2	4			glutamatergic neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+SLC17A7_RORB_FOXP2_DCC-positive neuron		DB:0000070	Neuron_SLC17A7_RORB_FOXP2_DCC	4			glutamatergic neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+SLC17A7_THEMIS-positive neuron		DB:0000064	Neuron_SLC17A7_THEMIS	4			glutamatergic neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+SLC17A7_THEMIS_DCC-positive neuron		DB:0000065	Neuron_SLC17A7_THEMIS_DCC	4			glutamatergic neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+SLC17A7_TLE4_FOXP2-positive neuron		DB:0000066	Neuron_SLC17A7_TLE4_FOXP2	4			glutamatergic neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+SLC17A7_TLE4_FOXP2_DCC-positive neuron		DB:0000067	Neuron_SLC17A7_TLE4_FOXP2_DCC	4			glutamatergic neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+chondrocyte	chondrocyte	CL:0000138	Chondrocyte	2							connective tissue cell	CL:0002320	cell	CL:0000548
+cortical cell of adrenal gland	cortical cell of adrenal gland	CL:0002097	Adrenocortical	3					glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	cell	CL:0000548
+chromaffin cell	chromaffin cell	CL:0000166	Chromaffin	4			neuroendocrine cell	CL:0000165	endocrine cell	CL:0000163	secretory cell	CL:0000151	cell	CL:0000548
+corneal epithelial cell	corneal epithelial cell	CL:0000575	CornealEpithelial	3					ecto-epithelial cell	CL:0002077	epithelial cell	CL:0000066	cell	CL:0000548
+enteric neuron	enteric neuron	CL:0007011	EntericNeuron	3					neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+cardiocyte	cardiocyte	CL:0002494	Cardiocyte	1									cell	CL:0000548
+extravillous trophoblast	extravillous trophoblast	CL:0008036	ExtravillousTrophoblast	3					trophoblast cell	CL:0000351	extraembryonic cell	CL:0000349	cell	CL:0000548
+trophoblast cell	trophoblast cell	CL:0000351	Trophoblast	2							extraembryonic cell	CL:0000349	cell	CL:0000548
+extraembryonic cell	extraembryonic cell	CL:0000349	Extraembryonic	1									cell	CL:0000548
+hepatoblast	hepatoblast	CL:0005026	Hepatoblast	4			multi fate stem cell	CL:0000048	stem cell	CL:0000034	precursor cell	CL:0011115	cell	CL:0000548
+inhibitory interneuron	inhibitory interneuron	CL:0000498	InhibitoryInterneuron	4			interneuron	CL:0000099	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+lens fiber cell	lens fiber cell	CL:0011004	LensFiber	3					vertebrate lens cell	CL:0002222	epithelial cell	CL:0000066	cell	CL:0000548
+vertebrate lens cell	vertebrate lens cell	CL:0002222	VertebrateLens	2							epithelial cell	CL:0000066	cell	CL:0000548
+chief cell of parathyroid gland	chief cell of parathyroid gland	CL:0000446	ParathyroidGlandChief	4			epithelial cell of parathyroid gland	CL:0002260	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	cell	CL:0000548
+epithelial cell of parathyroid gland	epithelial cell of parathyroid gland	CL:0002260	ParathyroidGlandEpithelial	3					endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	cell	CL:0000548
+retinal progenitor cell	retinal progenitor cell	CL:0002672	RetinalProgenitor	4			multi fate stem cell	CL:0000048	stem cell	CL:0000034	precursor cell	CL:0011115	cell	CL:0000548
+squamous epithelial cell	squamous epithelial cell	CL:0000076	SquamousEpithelial	2							epithelial cell	CL:0000066	cell	CL:0000548
+epithelial cell of thymus	epithelial cell of thymus	CL:0002293	ThymusEpithelial	3					endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	cell	CL:0000548
+thymocyte	thymocyte	CL:0000893	Thymocyte	5	immature T cell	CL:0002420	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+trophoblast giant cell	trophoblast giant cell	CL:0002488	TrophoblastGiant	3					trophoblast cell	CL:0000351	extraembryonic cell	CL:0000349	cell	CL:0000548
+visceromotor neuron	visceromotor neuron	CL:0005025	VisceromotorN	5	motor neuron	CL:0000100	efferent neuron	CL:0000527	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+motor neuron	motor neuron	CL:0000100	MotorN	4			efferent neuron	CL:0000527	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+efferent neuron	efferent neuron	CL:0000527	EfferentN	3					neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+fat cell	fat cell	CL:0000136	Adipocyte	2							connective tissue cell	CL:0002320	cell	CL:0000548
+epicardial adipocyte	epicardial adipocyte	CL:1000309	EpicardialAdipocyte	3					fat cell	CL:000136	connective tissue cell	CL:0002320	cell	CL:0000548
+Slamf1-positive multipotent progenitor cell	Slamf1-positive multipotent progenitor cell	CL:0002036	MultipotentPC_SLAMF	4			hematopoietic multipotent progenitor cell	CL:0000837	hematopoietic precursor cell	CL:0008001	hematopoietic cell	CL:0000988	cell	CL:0000548
+proliferating natural killer cell		DB:0000086	ProlifNKcell	5	natural killer cell	CL:0000623	innate lymphoid cell	CL:0001065	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+B myeloid cell doublet		DB:0000087	BMyeloid	2							hematopoietic cell	CL:0000988	cell	CL:0000548
+"BEST4+ intestinal epithelial cell, human"	"BEST4+ intestinal epithelial cell, human"	CL:4030026	BEST4enterocyte	5	enterocyte	CL:0000584	intestinal epithelial cell	CL:0002563	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	cell	CL:0000548
+T follicular helper cell	T follicular helper cell	CL:0002038	FollicularTh	5	"CD4-positive, alpha-beta T cell"	CL:0000624	T cell	CL:0000084	lymphocyte	CL:0000542	hematopoietic cell	CL:0000988	cell	CL:0000548
+capillary endothelial cell	capillary endothelial cell	CL:0002144	CapillaryEndothelial	4			blood vessel endothelial cell	CL:0000071	endothelial cell of vascular tree	CL:0002139	endothelial cell	CL:0000115	cell	CL:0000548
+colon macrophage	colon macrophage	CL:0009038	ColonMacrophage	4			macrophage	CL:0000235	myeloid leukocyte	CL:0000766	hematopoietic cell	CL:0000988	cell	CL:0000548
+endothelial cell of artery	endothelial cell of artery	CL:1000413	EndothelialArtery	4			blood vessel endothelial cell	CL:0000071	endothelial cell of vascular tree	CL:0002139	endothelial cell	CL:0000115	cell	CL:0000548
+tuft cell of colon	tuft cell of colon	CL:0009041	TuftColon	5	brush cell of epithelium proper of large intestine	CL:0002203	brush cell	CL:0002204	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	cell	CL:0000548
+vein endothelial cell	vein endothelial cell	CL:0002543	VeinEndothelial	4			blood vessel endothelial cell	CL:0000071	endothelial cell of vascular tree	CL:0002139	endothelial cell	CL:0000115	cell	CL:0000548
+molecular layer interneuron	molecular layer interneuron	DB:0000089	MLInterneuron	5	CNS interneuron	CL:0000402	central nervous system neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+CNS interneuron	CNS interneuron	CL:0000402	CNSInterneuron	4			central nervous system neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+unipolar brush cell	unipolar brush cell	CL:4023161	UnipolarBrush	5	CNS interneuron	CL:0000402	central nervous system neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+purkinje layer interneuron	purkinje layer interneuron	DB:0000090	PLInterneuron	5	CNS interneuron	CL:0000402	central nervous system neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+hepatic stellate cell	hepatic stellate cell	CL:0000632	HepStellate	3					fibroblast	CL:0000057	connective tissue cell	CL:0002320	cell	CL:0000548
+centrilobular region hepatocyte	centrilobular region hepatocyte	CL:0019029	CentrilobularHepatocyte	3					hepatocyte	CL:0000182	epithelial cell	CL:0000066	cell	CL:0000548
+midzonal region hepatocyte	midzonal region hepatocyte	CL:0019028	MidzonalHepatocyte	3					hepatocyte	CL:0000182	epithelial cell	CL:0000066	cell	CL:0000548
+periportal region hepatocyte	periportal region hepatocyte	CL:0019026	PeriportalHepatocyte	3					hepatocyte	CL:0000182	epithelial cell	CL:0000066	cell	CL:0000548
+enteric glial precursor cell	enteric glial precursor cell	DB:0000091	EntericGlialPC	4			enteric glial cell	DB:0000050	glial cell	CL:0000125	neural cell	CL:0002319	cell	CL:0000548
+glandular cell of stomach	glandular cell of stomach	CL:0002659	GlandularStomach	3					glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	cell	CL:0000548
+mucous cell of stomach	mucous cell of stomach	CL:0002180	MucousStomach	4			glandular cell of stomach	CL:0002659	glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	cell	CL:0000548
+parietal cell	parietal cell	CL:0000162	ParietalCell	4			glandular cell of stomach	CL:0002659	glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	cell	CL:0000548
+peptic cell	peptic cell	CL:0000155	PepticCell	4			glandular cell of stomach	CL:0002659	glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	cell	CL:0000548
+stomach enteroendocrine cell	stomach enteroendocrine cell	CL:1001517	StomachEnteroendocrine	4			glandular cell of stomach	CL:0002659	glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	cell	CL:0000548
+short term hematopoietic stem cell	short term hematopoietic stem cell	CL:0002033	STHematoStem	4			hematopoietic stem cell	CL:0000037	hematopoietic precursor cell	CL:0008001	hematopoietic cell	CL:0000988	cell	CL:0000548
+type I muscle cell	type I muscle cell	CL:0002211	TypeIMuscle	4			skeletal muscle fiber	CL:0008002	muscle cell	CL:0000187	contractile cell	CL:0000183	cell	CL:0000548
+type II muscle cell	type II muscle cell	CL:0002212	TypeIIMuscle	4			skeletal muscle fiber	CL:0008002	muscle cell	CL:0000187	contractile cell	CL:0000183	cell	CL:0000548
+glandular cell of esophagus	glandular cell of esophagus	CL:0002657	EsophagusGlandular	3					glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	cell	CL:0000548
+mesothelial fibroblast of the leptomeninx	mesothelial fibroblast of the leptomeninx	CL:4023058	MesoFibroblastLeptomeninx	2							neural cell	CL:0002319	cell	CL:0000548
+vascular leptomeningeal cell	vascular leptomeningeal cell	CL:4023051	VascLeptomeningeal	3					mesothelial fibroblast of the leptomeninx	CL:4023058	neural cell	CL:0002319	cell	CL:0000548
+chromophil cell of anterior pituitary gland	chromophil cell of anterior pituitary gland	CL:0000637	ChromophilAnteriorPituitary	2							neural cell	CL:0002319	cell	CL:0000548
+acidophil cell of pars distalis of adenohypophysis	acidophil cell of pars distalis of adenohypophysis	CL:0000638	AcidophilParsDistalis	3					chromophil cell of anterior pituitary gland	CL:0000637	neural cell	CL:0002319	cell	CL:0000548
+basophil cell of pars distalis of adenohypophysis	basophil cell of pars distalis of adenohypophysis	CL:0000639	BasophilParsDistalis	3					chromophil cell of anterior pituitary gland	CL:0000637	neural cell	CL:0002319	cell	CL:0000548
+mammotroph	mammotroph	CL:0002311	Mammotroph	4			acidophil cell of pars distalis of adenohypophysis	CL:0000638	chromophil cell of anterior pituitary gland	CL:0000637	neural cell	CL:0002319	cell	CL:0000548
+somatotroph	somatotroph	CL:0002312	Somatotroph	4			acidophil cell of pars distalis of adenohypophysis	CL:0000638	chromophil cell of anterior pituitary gland	CL:0000637	neural cell	CL:0002319	cell	CL:0000548
+mammosomatotroph	mammosomatotroph	CL:0002310	Mammosomatotroph	4			acidophil cell of pars distalis of adenohypophysis	CL:0000638	chromophil cell of anterior pituitary gland	CL:0000637	neural cell	CL:0002319	cell	CL:0000548
+corticotroph	corticotroph	CL:0002309	Corticotroph	4			basophil cell of pars distalis of adenohypophysis	CL:0000639	chromophil cell of anterior pituitary gland	CL:0000637	neural cell	CL:0002319	cell	CL:0000548
+gonadtroph	gonadtroph	CL:0000437	Gonadtroph	4			basophil cell of pars distalis of adenohypophysis	CL:0000639	chromophil cell of anterior pituitary gland	CL:0000637	neural cell	CL:0002319	cell	CL:0000548
+thyrotroph	thyrotroph	CL:0000476	Thyrotroph	4			basophil cell of pars distalis of adenohypophysis	CL:0000639	chromophil cell of anterior pituitary gland	CL:0000637	neural cell	CL:0002319	cell	CL:0000548
+melanotroph	melanotroph	DB:0000092	Melanotroph	4			basophil cell of pars distalis of adenohypophysis	CL:0000639	chromophil cell of anterior pituitary gland	CL:0000637	neural cell	CL:0002319	cell	CL:0000548
+sst GABAergic cortical interneuron	sst GABAergic cortical interneuron	CL:4023017	GABAergicInterneuron_SST	4			interneuron	CL:0002306	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+pvalb GABAergic cortical interneuron	pvalb GABAergic cortical interneuron	CL:4023018	GABAergicInterneuron_PVALB	4			interneuron	CL:0002306	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+reelin GABAergic cortical interneuron	reelin GABAergic cortical interneuron	CL:4032001	GABAergicInterneuron_REELIN	4			interneuron	CL:0002306	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+lamp5 GABAergic cortical interneuron	lamp5 GABAergic cortical interneuron	CL:4023011	GABAergicInterneuron_LAMP5	4			interneuron	CL:0002306	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+vip GABAergic cortical interneuron	vip GABAergic cortical interneuron	CL:4023016	GABAergicInterneuron_VIP	4			interneuron	CL:0002306	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+GABAergic amacrine cell	GABAergic amacrine cell	CL:4030027	GABAergicAmacrine	3					amacrine cell	CL:0000561	neural cell	CL:0002319	cell	CL:0000548
+glycinergic amacrine cell	glycinergic amacrine cell	CL:4030028	GlycinergicAmacrine	3					amacrine cell	CL:0000561	neural cell	CL:0002319	cell	CL:0000548
+adipocyte progenitor cell		DB:0000093	AdipocytePC	3					fat cell	CL:0000136	connective tissue cell	CL:0002320	cell	CL:0000548
+type I cell of adrenal cortex	type I cell of adrenal cortex	CL:0002099	TypeICorticalAdrenal	4			cortical cell of adrenal gland	CL:0002097	glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	cell	CL:0000548
+type II cell of adrenal cortex	type II cell of adrenal cortex	CL:0002136	TypeIICorticalAdrenal	4			cortical cell of adrenal gland	CL:0002097	glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	cell	CL:0000548
+adrenal medulla chromaffin cell	adrenal medulla chromaffin cell	CL:0000336	AdrenalMedullaChromaffin	5	chromaffin cell	CL:0000166	neuroendocrine cell	CL:0000165	endocrine cell	CL:0000163	secretory cell	CL:0000151	cell	CL:0000548
+stromal cell of endometrium	stromal cell of endometrium	CL:0002255	StromalEndometrium	3					stromal cell	CL:0000499	connective tissue cell	CL:0002320	cell	CL:0000548
+epithelial cell of thyroid gland	epithelial cell of thyroid gland	CL:0002257	ThyroidGlandEpithelial	3					glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	cell	CL:0000548
+thyroid follicular cell	thyroid follicular cell	CL:0002258	ThyroidFollicular	4			epithelial cell of thyroid gland	CL:0002257	glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	cell	CL:0000548
+meso-epithelial cell	meso-epithelial cell	CL:0002078	MesoEpithelial	2							epithelial cell	CL:0000066	cell	CL:0000548
+follicular cell of ovary	follicular cell of ovary	CL:0002174	OvaryFollicular	3					meso-epithelial cell	CL:0002078	epithelial cell	CL:0000066	cell	CL:0000548
+granulosa cell	granulosa cell	CL:0000501	Granulosa	4			follicular cell of ovary	CL:0002174	meso-epithelial cell	CL:0002078	epithelial cell	CL:0000066	cell	CL:0000548
+stromal cell of ovary	stromal cell of ovary	CL:0002132	StromalOvary	3					stromal cell	CL:0000499	connective tissue cell	CL:0002320	cell	CL:0000548
+theca cell	theca cell	CL:0000503	Theca	4			stromal cell of ovary	CL:0002132	stromal cell	CL:0000499	connective tissue cell	CL:0002320	cell	CL:0000548
+luteal cell	luteal cell	CL:0000175	Luteal	4			stromal cell of ovary	CL:0002132	stromal cell	CL:0000499	connective tissue cell	CL:0002320	cell	CL:0000548
+ovarian surface epithelial cell	ovarian surface epithelial cell	CL:2000064	OvarianSurfaceEpithelial	2							epithelial cell	CL:0000066	cell	CL:0000548
+peg cell	peg cell	CL:4033014	PegCell	2							epithelial cell	CL:0000066	cell	CL:0000548
+neurecto-epithelial cell	neurecto-epithelial cell	CL:0000710	NeurectoEpithelial	3					ecto-epithelial cell	CL:0002077	epithelial cell	CL:0000066	cell	CL:0000548
+type I cell of carotid body	type I cell of carotid body	CL:0002292	TypeICarotidBody	4			neurecto-epithelial cell	CL:0000710	ecto-epithelial cell	CL:0002077	epithelial cell	CL:0000066	cell	CL:0000548
+urothelial cell	urothelial cell	CL:0000731	Urothelial	2							epithelial cell	CL:0000066	cell	CL:0000548
+basal cell of urothelium	basal cell of urothelium	CL:1000486	UrothelialBasal	3					urothelial cell	CL:0000731	epithelial cell	CL:0000066	cell	CL:0000548
+intermediate cell of urothelium	intermediate cell of urothelium	CL:4030055	UrothelialIntermediate	3					urothelial cell	CL:0000731	epithelial cell	CL:0000066	cell	CL:0000548
+umbrella cell of urothelium	umbrella cell of urothelium	CL:4030056	UrothelialUmbrella	3					urothelial cell	CL:0000731	epithelial cell	CL:0000066	cell	CL:0000548
+oral mucosa squamous cell	oral mucosa squamous cell	CL:1001576	OralMucosaSquamous	3					squamous epithelial cell	CL:0000076	epithelial cell	CL:0000066	cell	CL:0000548
+keratinized cell of the oral mucosa	keratinized cell of the oral mucosa	CL:0000237	OralMucosaKeratinized	3					ecto-epithelial cell	CL:0002077	epithelial cell	CL:0000066	cell	CL:0000548
+sensory neuron	sensory neuron	CL:0000101	SensoryNeuron	3					neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+meningothelial cell	meningothelial cell	CL:0002379	Meningothelial	4			neurecto-epithelial cell	CL:0000710	ecto-epithelial cell	CL:0002077	epithelial cell	CL:0000066	cell	CL:0000548
+tendon cell	tendon cell	CL:0000388	Tendon	2							stromal cell	CL:0000499	cell	CL:0000548
+fibro/adipogenic progenitor cell	fibro/adipogenic progenitor cell	CL:0009099	FibroAdipogenicProgenitor	2							mesenchymal cell	CL:0008019	cell	CL:0000548
+epithelial cell of prostate	epithelial cell of prostate	CL:0002231	ProstateEpithelial	3					endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	cell	CL:0000548
+luminal cell of prostate epithelium	luminal cell of prostate epithelium	CL:0002340	LuminalProstateEpithelium	4			epithelial cell of prostate	CL:0002231	endo-epithelial cell	CL:0002076	epithelial cell	CL:0000066	cell	CL:0000548
+clear cell		DB:0000094	Clear	3					ionocyte	CL:0005006	epithelial cell	CL:0000066	cell	CL:0000548
+renal intercalated cell	renal intercalated cell	CL:0005010	RenalIntercalated	3					epithelial cell of nephron	CL:1000449	epithelial cell	CL:0000066	cell	CL:0000548
+renal alpha-intercalated cell	renal alpha-intercalated cell	CL:0005011	RenalAlphaIntercalated	4			renal intercalated cell	CL:0005011	epithelial cell of nephron	CL:1000449	epithelial cell	CL:0000066	cell	CL:0000548
+renal beta-intercalated cell	renal beta-intercalated cell	CL:0002201	RenalBetaIntercalated	4			renal intercalated cell	CL:0005011	epithelial cell of nephron	CL:1000449	epithelial cell	CL:0000066	cell	CL:0000548
+renal principal cell	renal principal cell	CL:0005009	RenalPrincipal	3					epithelial cell of nephron	CL:1000449	epithelial cell	CL:0000066	cell	CL:0000548
+glomerular endothelial cell	glomerular endothelial cell	CL:0002188	GlomerularEndo	2							endothelial cell	CL:0000115	cell	CL:0000548
+vasa recta ascending limb cell	vasa recta ascending limb cell	CL:1001131	VasaRectaAscending	4			kidney capillary endothelial cell	CL:1000892	blood vessel endothelial cell	CL:0000071	endothelial cell	CL:0000115	cell	CL:0000548
+vasa recta descending limb cell	vasa recta descending limb cell	CL:1001285	VasaRectaDescending	4			kidney capillary endothelial cell	CL:1000892	blood vessel endothelial cell	CL:0000071	endothelial cell	CL:0000115	cell	CL:0000548
+peritubular capillary endothelial cell	peritubular capillary endothelial cell	CL:1001033	PeritubularCapillaryEndo	4			kidney capillary endothelial cell	CL:1000892	blood vessel endothelial cell	CL:0000071	endothelial cell	CL:0000115	cell	CL:0000548
+renal filtration cell	renal filtration cell	CL:0002522	RenalFiltration	2							secretory cell	CL:0000151	cell	CL:0000548
+kidney interstitial myofibroblast	kidney interstitial myofibroblast	CL:1000691	KidneyInterstitialMyofibroblast	3					myofibroblast cell	CL:0000186	contractile cell	CL:0000183	cell	CL:0000548
+kidney pelvis urothelial cell	kidney pelvis urothelial cell	CL:1000703	KidneyPelvisUrothelial	3					kidney pelvis urothelial cell	CL:1000703	epithelial cell	CL:0000066	cell	CL:0000548
+kidney connecting tubule principal cell	kidney connecting tubule principal cell	CL:4030018	KidneyConnectingTubulePrincipal	4			renal principal cell	CL:0005009	epithelial cell of nephron	CL:1000449	epithelial cell	CL:0000066	cell	CL:0000548
+kidney precursor cell		DB:0000095	KidneyPrecursor	2							precursor cell	CL:0011115	cell	CL:0000548
+pronephric nephron cell		DB:0000096	PronephricNephron	3					kidney precursor cell	DB:0000095	precursor cell	CL:0011115	cell	CL:0000548
+ureteric bud cell		DB:0000097	UretericBud	3					kidney precursor cell	DB:0000095	precursor cell	CL:0011115	cell	CL:0000548
+ureteric bud epithelial cell		DB:0000098	UretericBudEpithelial	4			ureteric bud cell	DB:0000097	kidney precursor cell	DB:0000095	precursor cell	CL:0011115	cell	CL:0000548
+renal vesicle cell		DB:0000099	RenalVesicle	3					kidney precursor cell	DB:0000095	precursor cell	CL:0011115	cell	CL:0000548
+metanephric mesenchyme cell		DB:0000100	MetanephricMesenchyme	3					kidney precursor cell	DB:0000095	precursor cell	CL:0011115	cell	CL:0000548
+S shaped body cell		DB:0000101	SshapedBody	3					kidney precursor cell	DB:0000095	precursor cell	CL:0011115	cell	CL:0000548
+kidney collecting duct principal cell	kidney collecting duct principal cell	CL:1001431	KidneyDuctPrincipal	4			kidney collecting duct cell	CL:1001225	duct epithelial cell	CL:0000068	epithelial cell	CL:0000066	cell	CL:0000548
+kidney outer medulla collecting duct principal cell	kidney outer medulla collecting duct principal cell	CL:1000716	KidneyOuterMedullaDuctPrincipal	5	kidney collecting duct principal cell	CL:1001431	kidney collecting duct cell	CL:1001225	duct epithelial cell	CL:0000068	epithelial cell	CL:0000066	cell	CL:0000548
+kidney inner medulla collecting duct principal cell	kidney inner medulla collecting duct principal cell	CL:1000718	KidneyInnerMedullaDuctPrincipal	5	kidney collecting duct principal cell	CL:1001431	kidney collecting duct cell	CL:1001225	duct epithelial cell	CL:0000068	epithelial cell	CL:0000066	cell	CL:0000548
+kidney collecting duct intercalated cell	kidney collecting duct intercalated cell	CL:1001432	KidneyDuctIntercalated	4			kidney collecting duct cell	CL:1001225	duct epithelial cell	CL:0000068	epithelial cell	CL:0000066	cell	CL:0000548
+kidney collecting duct beta-intercalated cell	kidney collecting duct beta-intercalated cell	CL:4030005	KidneyDuctBetaIntercalated	5	kidney collecting duct intercalated cell	CL:1001432	kidney collecting duct cell	CL:1001225	duct epithelial cell	CL:0000068	epithelial cell	CL:0000066	cell	CL:0000548
+kidney collecting duct alpha-intercalated cell	kidney collecting duct alpha-intercalated cell	CL:4030015	KidneyDuctAlphaIntercalated	5	kidney collecting duct intercalated cell	CL:1001432	kidney collecting duct cell	CL:1001225	duct epithelial cell	CL:0000068	epithelial cell	CL:0000066	cell	CL:0000548
+podocyte	podocyte	CL:0000653	Podocyte	4			kidney glomerular epithelial cell	CL:1000510	epithelial cell of nephron	CL:1000449	epithelial cell	CL:0000066	cell	CL:0000548
+kidney proximal convoluted tubule epithelial cell	kidney proximal convoluted tubule epithelial cell	CL:1000838	ProxConvolutedTubule	4			epithelial cell of proximal tubule	CL:0002306	epithelial cell of nephron	CL:1000449	epithelial cell	CL:0000066	cell	CL:0000548
+kidney loop of Henle ascending limb epithelial cell	kidney loop of Henle ascending limb epithelial cell	CL:1001016	HenleAscendingTubule	4			kidney loop of Henle epithelial cell	CL:1000909	epithelial cell of nephron	CL:1000449	epithelial cell	CL:0000066	cell	CL:0000548
+kidney loop of Henle descending limb epithelial cell	kidney loop of Henle descending limb epithelial cell	CL:1001021	HenleDescendingTubule	4			kidney loop of Henle epithelial cell	CL:1000909	epithelial cell of nephron	CL:1000449	epithelial cell	CL:0000066	cell	CL:0000548
+papillary tips cell	papillary tips cell	CL:1000597	PapillaryTips	2							epithelial cell	CL:0000066	cell	CL:0000548
+glomerular mesangial cell	glomerular mesangial cell	CL:1000742	GlomerularMesangial	4			mesangial cell	CL:0000650	pericyte	CL:0000669	connective tissue cell	CL:0002320	cell	CL:0000548
+kidney glomerular epithelial cell	kidney glomerular epithelial cell	CL:1000510	GlomerularEpithelial	3					epithelial cell of nephron	CL:1000449	epithelial cell	CL:0000066	cell	CL:0000548
+apical cell		DB:0000106	Apical	2							epithelial cell	CL:0000066	cell	CL:0000548
+epithelial cell of gallbladder	epithelial cell of gallbladder	CL:1000415	GallbladderEpithelial	2							epithelial cell	CL:0000066	cell	CL:0000548
+intercalated duct cell		DB:0000102	IntercalatedDuct	3					duct epithelial cell	CL:0000068	epithelial cell	CL:0000066	cell	CL:0000548
+principal cell		DB:0000105	Principal	2							epithelial cell	CL:0000066	cell	CL:0000548
+myoepithelial cell	myoepithelial cell	CL:0000185	Myoepithelial	2							contractile cell	CL:0000183	cell	CL:0000548
+myotendinous junction muscle nuclei		DB:0000103	MyotendinousJunctionNuclei	4			skeletal muscle fiber	CL:0008002	muscle cell	CL:0000187	contractile cell	CL:0000183	cell	CL:0000548
+neuromuscular junction muscle nuclei		DB:0000104	NeuromuscularJunctionNuclei	4			skeletal muscle fiber	CL:0008002	muscle cell	CL:0000187	contractile cell	CL:0000183	cell	CL:0000548
+peritubular myoid cell	peritubular myoid cell	CL:0002481	PeritubularMyoid	3					myoepithelial cell	CL:0000185	contractile cell	CL:0000183	cell	CL:0000548
+pinealocyte	pinealocyte	CL:0000652	Pinealocyte	2							neural cell	CL:0002319	cell	CL:0000548
+plasmablast	plasmablast	CL:0000980	Plasmablast	3					lymphocyte of B lineage	CL:0000945	hematopoietic cell	CL:0000988	cell	CL:0000548
+SLC17A7_CUX2-positive neuron		DB:0000060	Neuron_SLC17A7_CUX2	4			glutamatergic neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+SLC17A7_THY1-positive neuron		DB:0000088	Neuron_SLC17A7_THY1	4			glutamatergic neuron	CL:0000679	neuron	CL:0000540	neural cell	CL:0002319	cell	CL:0000548
+sweat secreting cell	sweat secreting cell	CL:0000318	SweatSecreting	3					glandular epithelial cell	CL:0000150	epithelial cell	CL:0000066	cell	CL:0000548


### PR DESCRIPTION
Adjusted dblabel nomenclature table to include the full updated kidney hierarchy as well as a few additional terms that were missing + removed some obsolute terms & changed animal cell => cell, as per CL update. Pls double-check that it works for you & I didn't introduce formatting errors. 