### PR TITLE
Bugfix: #371

### DIFF
--- a/besca/Import/_read.py
+++ b/besca/Import/_read.py
@@ -138,7 +138,7 @@ def read_mtx(
     if gzfiles == "gz":
         print("reading matrix.mtx.gz")
         adata = read(
-            os.path.join(filepath, "matrix.mtx.gz"), cache=True
+            os.path.join(filepath, "matrix.mtx.gz"), cache=False
         ).T  # transpose the data
         print("adding cell barcodes")
         adata.obs_names = pd.read_csv(
@@ -155,7 +155,7 @@ def read_mtx(
     else:
         print("reading matrix.mtx")
         adata = read(
-            os.path.join(filepath, "matrix.mtx"), cache=True
+            os.path.join(filepath, "matrix.mtx"), cache=False
         ).T  # transpose the data
         print("adding cell barcodes")
         adata.obs_names = pd.read_csv(

--- a/besca/pp/_normalization.py
+++ b/besca/pp/_normalization.py
@@ -1,5 +1,6 @@
 import numpy as np
 from scipy.sparse.csr import csr_matrix
+from scipy.sparse._csc import csc_matrix
 from anndata._core.views import SparseCSRView
 
 def closure(mat):
@@ -179,6 +180,9 @@ def normalize_geometric(adata):
         X = X.todense()
     # need to add a catch for newly encountered datatype
     elif type(X) == SparseCSRView:
+        X = X.todense()
+    # need to add a catch for new sparse matrix datatype
+    elif type(X) == csc_matrix:
         X = X.todense()
 
     # ensure that X is an array otherwise this will cause type issue with multiplicative replacement function

--- a/workbooks/standard_workflow_besca2.ipynb
+++ b/workbooks/standard_workflow_besca2.ipynb
@@ -760,7 +760,7 @@
     "        n_prots = len(adata_prot.var_names)\n",
     "        percent_top = (int(round(0.01*n_prots, 0)) if int(round(0.01*n_prots, 0)) >= 1 else 1, int(round(0.1*n_prots, 0)), int(round(0.25*n_prots, 0)))\n",
     "        qc_adata = sc.pp.calculate_qc_metrics(adata_prot, percent_top=percent_top, var_type=\"antibodies\", inplace=False)\n",
-    "        fig = sns.jointplot(\"log1p_total_counts\", \"n_antibodies_by_counts\", qc_adata[0], kind=\"hex\", norm=mpl.colors.LogNorm())\n",
+    "        fig = sns.jointplot(x=\"log1p_total_counts\", y=\"n_antibodies_by_counts\", data=qc_adata[0], kind=\"hex\", norm=mpl.colors.LogNorm())\n",
     "        fig.savefig(os.path.join(results_folder_citeseq, 'citeseq', 'figures', 'CITESEQ_QC_plot.png'))\n",
     "        \n",
     "        #generate overview of n_counts\n",


### PR DESCRIPTION
Rerunning the pipeline with changed thresholds leads to an outdated .h5ad being loaded.
Setting cache=False when using scanpy read, resolves this issue.

Note: This pull request contains additional commits from previous pull requests.